### PR TITLE
feat : 조회수 중북 증가 방지 및 Redis 관련 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation('org.springframework.boot:spring-boot-starter-data-redis')
 	implementation 'com.h2database:h2'
 	implementation 'mysql:mysql-connector-java:8.0.33'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/kakaotech/team14backend/config/RedisConfig.java
+++ b/src/main/java/com/kakaotech/team14backend/config/RedisConfig.java
@@ -1,0 +1,65 @@
+package com.kakaotech.team14backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.redis.port}")
+  public int port;
+
+  @Value("${spring.redis.host}")
+  public String host;
+
+
+  @Bean
+  public LettuceConnectionFactory lettuceConnectionFactory(){
+    return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host,port));
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(lettuceConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());   // Key: String
+    redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));  // Value: 직렬화에 사용할 Object 사용하기
+    return redisTemplate;
+  }
+
+  /**
+   * 기본 캐시 설정
+   * ttl : 20분
+   */
+
+  @Bean
+  public RedisCacheConfiguration redisCacheConfiguration() {
+    return RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(Duration.ofMinutes(20))
+        .disableCachingNullValues()
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+        )
+        .serializeValuesWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+        );
+  }
+
+
+
+
+
+}

--- a/src/main/java/com/kakaotech/team14backend/inner/image/model/Image.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/image/model/Image.java
@@ -6,10 +6,13 @@ import com.kakaotech.team14backend.inner.post.model.Post;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 
 @Entity
+@Getter
 @NoArgsConstructor(access=PROTECTED)
 public class Image {
 
@@ -21,18 +24,17 @@ public class Image {
   private String imageUri; // 서버용 사진 저장 이름
 
   @Column(nullable = false)
+  @CreationTimestamp
   private LocalDateTime createdAt; // 생성일
 
   public static Image createImage(String imageUri){
     return Image.builder()
         .imageUri(imageUri)
-        .createdAt(LocalDateTime.now())
         .build();
   }
 
   @Builder
-  public Image(String imageUri, Long fileSize, LocalDateTime createdAt) {
+  public Image(String imageUri) {
     this.imageUri = imageUri;
-    this.createdAt = createdAt;
   }
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
@@ -12,10 +12,14 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access=PROTECTED)
+@Getter
 public class Member {
 
   @Id
@@ -45,5 +49,11 @@ public class Member {
 
   @Column(nullable = false,length = 20)
   private String userStatus; // 제재, 탈퇴, 정상 등등
+
+  @Builder
+  public Member(String userName,String kakaoId) {
+    this.userName = userName;
+    this.kakaoId = kakaoId;
+  }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/member/usecase/FindMemberUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/member/usecase/FindMemberUsecase.java
@@ -11,8 +11,8 @@ public class FindMemberUsecase {
 
   private final MemberRepository memberRepository;
 
-  public Member execute(Long userId) {
-    return memberRepository.findById(userId).orElseThrow(
+  public Member execute(Long memberId) {
+    return memberRepository.findById(memberId).orElseThrow(
         () -> new RuntimeException("Member not found")
     );
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -7,10 +7,12 @@ import com.kakaotech.team14backend.inner.member.model.Member;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
+@Getter
 public class Post {
 
   // Primary Key

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -81,7 +81,7 @@ public class Post {
 
 
   @Builder
-  public Post(String boothName, String nickname, Boolean published, String hashtag,
+  public Post(String nickname, Boolean published, String hashtag,
       String university, Long viewCount, Long popularity, Integer reportCount) {
     this.nickname = nickname;
     this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -45,13 +45,13 @@ public class Post {
 
   // Statistics
   @Column(nullable = true)
-  private Long viewCount = 0L; // 조회수
+  private Long viewCount; // 조회수
 
   @Column(nullable = false)
   private Long popularity; // 인기도 값
 
   @Column(nullable = false)
-  private Integer reportCount = 0; // 제재 횟수
+  private Integer reportCount; // 제재 횟수
 
   public void mappingMember(Member member) {
     this.member = member;
@@ -62,11 +62,18 @@ public class Post {
   }
 
   public static Post createPost(Member member, Image image, String nickname, Boolean published,
-      String hashtag, String university, Long viewCount, Long popularity, Integer reportCount) {
+      String hashtag, String university) {
 
-    Post post = Post.builder().nickname(nickname).published(published).hashtag(hashtag)
-        .university(university).viewCount(viewCount).popularity(popularity).reportCount(reportCount)
+    Post post = Post.builder()
+        .nickname(nickname)
+        .published(published)
+        .hashtag(hashtag)
+        .university(university)
+        .viewCount(0L)
+        .popularity(0L)
+        .reportCount(0)
         .build();
+
     post.mappingMember(member);
     post.mappingImage(image);
     return post;

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/CreatePostUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/CreatePostUsecase.java
@@ -21,7 +21,7 @@ public class CreatePostUsecase {
     String attachedHashTag = attachHashTags(uploadPostRequestDTO.getHashTags());
 
     Post post = Post.createPost(member, image, uploadPostRequestDTO.getNickname(), true,
-        attachedHashTag, uploadPostRequestDTO.getUniversity(), 0L, 0L, 0);
+        attachedHashTag, uploadPostRequestDTO.getUniversity());
     return postRepository.save(post);
   }
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/CreatePostUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/CreatePostUsecase.java
@@ -4,6 +4,7 @@ import com.kakaotech.team14backend.inner.image.model.Image;
 import com.kakaotech.team14backend.inner.member.model.Member;
 import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
+import com.kakaotech.team14backend.outer.post.dto.CreatePostDTO;
 import com.kakaotech.team14backend.outer.post.dto.UploadPostRequestDTO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,11 +18,9 @@ public class CreatePostUsecase {
   //우리가 알던 서비스
   private final PostRepository postRepository;
 
-  public Post execute(Image image, UploadPostRequestDTO uploadPostRequestDTO, Member member) {
-    String attachedHashTag = attachHashTags(uploadPostRequestDTO.getHashTags());
-
-    Post post = Post.createPost(member, image, uploadPostRequestDTO.getNickname(), true,
-        attachedHashTag, uploadPostRequestDTO.getUniversity());
+  public Post execute(CreatePostDTO createPostDTO) {
+    String attachedHashTag = attachHashTags(createPostDTO.uploadPostRequestDTO().getHashTags());
+    Post post = Post.createPost(createPostDTO.member(), createPostDTO.image(), createPostDTO.uploadPostRequestDTO().getNickname(), true, attachedHashTag, createPostDTO.uploadPostRequestDTO().getUniversity());
     return postRepository.save(post);
   }
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPostUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPostUsecase.java
@@ -1,0 +1,27 @@
+package com.kakaotech.team14backend.inner.post.usecase;
+
+import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.inner.post.repository.PostRepository;
+import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindPostUsecase {
+
+  private final PostRepository postRepository;
+  private final RedisTemplate<String,Object> redisTemplate;
+
+  public Post execute(GetPostDTO getPostDTO) {
+    redisTemplate.opsForSet().add(String.valueOf(getPostDTO.postId()),getPostDTO.memberId());
+    // todo 캐시 서버에 해당 게시글이 존재하는 지 확인하는 메서드
+    // todo 있다면, 캐시 서버에서 해당 게시글을 가져오는 메서드
+    Post post = postRepository.findById(getPostDTO.postId()).orElseThrow(() -> new RuntimeException("Post not found"));
+    return post;
+  }
+
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
@@ -2,27 +2,46 @@ package com.kakaotech.team14backend.outer.post.controller;
 
 import com.kakaotech.team14backend.common.ApiResponse;
 import com.kakaotech.team14backend.common.ApiResponseGenerator;
+import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
+import com.kakaotech.team14backend.outer.post.dto.GetPostResponseDTO;
+import com.kakaotech.team14backend.outer.post.dto.UploadPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.UploadPostRequestDTO;
 import com.kakaotech.team14backend.outer.post.service.PostService;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class PostController {
 
   private final PostService postService;
 
+  @PostMapping("/post")
   public ApiResponse<ApiResponse.CustomBody<Void>> uploadPost(@RequestPart MultipartFile image,
       @RequestPart UploadPostRequestDTO uploadPostRequestDTO) throws IOException {
 
-    Long userId = 1L;
-    postService.uploadPost(userId, image, uploadPostRequestDTO);
+    Long memberId = 1L;
+    UploadPostDTO uploadPostDTO = new UploadPostDTO(memberId, image, uploadPostRequestDTO);
+    postService.uploadPost(uploadPostDTO);
     return ApiResponseGenerator.success(HttpStatus.CREATED);
+  }
+
+
+  @GetMapping("/post/{postId}")
+  public ApiResponse<ApiResponse.CustomBody<GetPostResponseDTO>> getPost(@PathVariable("boadId") Long postId){
+    Long memberId = 1L;
+    GetPostDTO getPostDTO = new GetPostDTO(postId, memberId);
+    GetPostResponseDTO getPostResponseDTO = postService.getPost(getPostDTO);
+    return ApiResponseGenerator.success(getPostResponseDTO,HttpStatus.OK);
   }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/CreatePostDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/CreatePostDTO.java
@@ -1,0 +1,7 @@
+package com.kakaotech.team14backend.outer.post.dto;
+
+import com.kakaotech.team14backend.inner.image.model.Image;
+import com.kakaotech.team14backend.inner.member.model.Member;
+
+public record CreatePostDTO(Image image, UploadPostRequestDTO uploadPostRequestDTO, Member member) {
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostDTO.java
@@ -1,0 +1,4 @@
+package com.kakaotech.team14backend.outer.post.dto;
+
+public record GetPostDTO(Long postId, Long memberId) {
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostResponseDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostResponseDTO.java
@@ -1,0 +1,6 @@
+package com.kakaotech.team14backend.outer.post.dto;
+
+import java.util.List;
+
+public record GetPostResponseDTO(Long postId, String imageUri, List<String> hashTags, Integer likeCount, Integer boardPoint, String nickname) {
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/UploadPostDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/UploadPostDTO.java
@@ -1,0 +1,6 @@
+package com.kakaotech.team14backend.outer.post.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UploadPostDTO(Long memberId, MultipartFile image,UploadPostRequestDTO uploadPostRequestDTO) {
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
@@ -1,0 +1,22 @@
+package com.kakaotech.team14backend.outer.post.mapper;
+
+import com.kakaotech.team14backend.inner.image.model.Image;
+import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.outer.post.dto.GetPostResponseDTO;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PostMapper {
+
+  public static GetPostResponseDTO from(Post post){
+    return new GetPostResponseDTO(post.getPostId(),post.getImage().getImageUri(), splitHashtag(post.getHashtag()), 0, 0, post.getNickname());
+  }
+
+  private static List<String> splitHashtag(String hashTag){
+    String cuttingHashTag = hashTag.substring(1);
+    String[] splitHashtags = cuttingHashTag.split("#");
+    return Arrays.stream(splitHashtags).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
@@ -4,9 +4,17 @@ import com.kakaotech.team14backend.inner.image.model.Image;
 import com.kakaotech.team14backend.inner.image.usecase.CreateImageUsecase;
 import com.kakaotech.team14backend.inner.member.model.Member;
 import com.kakaotech.team14backend.inner.member.usecase.FindMemberUsecase;
+import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.inner.post.usecase.FindPostUsecase;
+import com.kakaotech.team14backend.outer.post.dto.CreatePostDTO;
+import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
+import com.kakaotech.team14backend.outer.post.dto.GetPostResponseDTO;
+import com.kakaotech.team14backend.outer.post.dto.UploadPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.UploadPostRequestDTO;
 import com.kakaotech.team14backend.inner.post.usecase.CreatePostUsecase;
 import java.io.IOException;
+
+import com.kakaotech.team14backend.outer.post.mapper.PostMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,12 +28,20 @@ public class PostService {
   private final CreateImageUsecase createImageUsecase;
   private final CreatePostUsecase createPostUsecase;
   private final FindMemberUsecase findMemberUsecase;
+  private final FindPostUsecase findPostUsecase;
 
   @Transactional
-  public void uploadPost(Long userId, MultipartFile image,
-      UploadPostRequestDTO uploadPostRequestDTO) throws IOException {
-    Member savedMember = findMemberUsecase.execute(userId);
-    Image savedImage = createImageUsecase.execute(image, uploadPostRequestDTO.getImageName());
-    createPostUsecase.execute(savedImage, uploadPostRequestDTO, savedMember);
+  public void uploadPost(UploadPostDTO uploadPostDTO) throws IOException {
+    Member savedMember = findMemberUsecase.execute(uploadPostDTO.memberId());
+    Image savedImage = createImageUsecase.execute(uploadPostDTO.image(), uploadPostDTO.uploadPostRequestDTO().getImageName());
+    CreatePostDTO createPostDTO = new CreatePostDTO(savedImage, uploadPostDTO.uploadPostRequestDTO(), savedMember);
+    createPostUsecase.execute(createPostDTO);
   }
+
+  public GetPostResponseDTO getPost(GetPostDTO getPostDTO) {
+    Post post = findPostUsecase.execute(getPostDTO);
+    GetPostResponseDTO getPostResponseDTO = PostMapper.from(post);
+    return getPostResponseDTO;
+  }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,11 +4,10 @@ spring.datasource.url = jdbc:h2:mem:Chookting;MODE=MySQL
 spring.datasource.driver-class-name = org.h2.Driver
 spring.datasource.username = admin
 spring.datasource.password = admin
-#
-#spring.datasource.url=jdbc:mysql://localhost:3306/test_kakao
-#spring.datasource.username=root
-#spring.datasource.password=
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.redis.host = 127.0.0.1
+spring.redis.port = 6379
+spring.redis.timeout = 3000
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPostUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPostUsecaseTest.java
@@ -1,0 +1,59 @@
+package com.kakaotech.team14backend.inner.post.usecase;
+
+import com.kakaotech.team14backend.config.RedisConfig;
+import com.kakaotech.team14backend.inner.image.model.Image;
+import com.kakaotech.team14backend.inner.member.model.Member;
+import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.inner.post.repository.PostRepository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Import(RedisConfig.class)
+@DataJpaTest
+class FindPostUsecaseTest {
+
+  @Autowired
+  private PostRepository postRepository;
+
+  @Autowired
+  private RedisTemplate redisTemplate;
+
+  @BeforeEach
+  @DisplayName("게시글 1을 회원 2와 회원 3이 방문한 경우")
+  void setUp() {
+
+    redisTemplate.delete("1");
+
+    Member member = new Member("sonny", "sonny1234");
+    Image image = new Image("/image/firstPhoto");
+    Post post = Post.createPost(member, image, "대선대선", true, "#가자", "전남대학교");
+    postRepository.save(post);
+    redisTemplate.opsForSet().add("1",2L);
+    redisTemplate.opsForSet().add("1",3L);
+  }
+
+  @Test
+  @DisplayName("게시글 1을 회원 2가 다시 방문한 경우 이는 기록이 되지 않는다.")
+  void execute_NotCount() {
+    redisTemplate.opsForSet().add("1",2L);
+    Long size = redisTemplate.opsForSet().size("1");
+    Assertions.assertThat(size).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("게시글 1을 회원 4가 다시 방문한 경우 이는 기록이 된다.")
+  void execute_findPost(){
+    redisTemplate.opsForSet().add("1",4L);
+    Long size = redisTemplate.opsForSet().size("1");
+    Assertions.assertThat(size).isEqualTo(3);
+  }
+
+
+}


### PR DESCRIPTION
이 PR에서는 조회수 중복 증가 방지 및 Redis 관련 설정 코드를 작성했습니다.

## 👨‍💻 구현 내용

- RedisTemplate의 Set 자료구조를 이용해 조회수 중복 증가 방지 기능 구현 
- 각 계층별(Controller, Service, Usecase, Mapper, Repository) 게시글 상세 조회 기능 구현
- 기존의 DTO 방식에서 Record 클래스를 DTO로 사용하는 방식으로 리팩토링 및 기능 구현
- RedisConfig 등과 같은 Redis 관련 설정
- FindPostUsecaseTest를 통해 조회수 중복 기능 검증

## 🔗 연관 이슈

- 이슈번호: #19 

## 기타

아직 해당 이슈관련 구현이 끝나지 않았으나, Redis관련 설정 공유를 위해 PR 함.