### PR TITLE
feat: Swagger 3.0 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation('org.springframework.boot:spring-boot-starter-data-redis')
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'com.h2database:h2'
 	implementation 'mysql:mysql-connector-java:8.0.33'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/kakaotech/team14backend/config/SwaggerConfig.java
+++ b/src/main/java/com/kakaotech/team14backend/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.kakaotech.team14backend.config;
+
+import com.sun.xml.bind.v2.schemagen.xmlschema.Appinfo;
+import java.util.Collections;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+  @Bean
+  public Docket api() {
+    return new Docket(DocumentationType.SWAGGER_2)
+        .select()
+        .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
+        .paths(PathSelectors.regex("/api/.*"))
+        .build()
+        .apiInfo(apiInfo());
+  }
+
+  private ApiInfo apiInfo() {
+    return new ApiInfo(
+        "Kakao Tech Team 14 Backend API",
+        "Team Spark Backend API for Kakao Tech Campus 2023",
+        "1.0",
+        "Terms of service",
+        new Contact("Name", "www.example.com", "email@example.com"),
+        "License of API", "API license URL", Collections.emptyList());
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
@@ -9,6 +9,7 @@ import com.kakaotech.team14backend.outer.post.dto.GetPostResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.UploadPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.UploadPostRequestDTO;
 import com.kakaotech.team14backend.outer.post.service.PostService;
+import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,6 +29,7 @@ public class PostController {
 
   private final PostService postService;
 
+  @ApiOperation(value = "홈 피드의 게시물 조회", notes = "마지막 게시물의 id를 받아서 그 이후의 게시물을 조회한다. lastPostId가 없다면 첫 게시물을 조회한다")
   @GetMapping("/post")
   public ApiResponse<CustomBody<GetPostListResponseDTO>> getPosts(
       @RequestParam(value = "lastPostId", required = false) Long lastPostId,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ spring.redis.timeout = 3000
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.h2.console.enabled=true
+
+#SpringBoot 2.6 ?? springfox-swagger3.0 ?? ? ?? ??
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher


### PR DESCRIPTION
## 변경 사항

- `SwaggerConfig.java` 설정 파일을 추가하여 Swagger 3.0 API 문서화를 활성화했습니다.
- 설정에서는 `@RestController` 애노테이션이 있는 컨트롤러만 문서화 대상으로 포함시켰습니다.
- 애플리케이션 프로퍼티에서 매칭 전략을 설정하여 swagger 3.0 경로 에러를 해결했습니다.

## 동기

- API 문서화를 개선하고, swagger 3.0 경로 에러를 해결하기 위함입니다.

## 테스트 계획

1. Swagger UI를 통해 모든 `@RestController` 애노테이션이 있는 컨트롤러가 문서화되었는지 확인합니다.
2. 경로 에러가 해결되어 API 문서가 올바르게 표시되는지 확인합니다.

## 연관 이슈

- 이슈 #27