### PR TITLE
게시글 좋아요 기능 추가

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -76,7 +76,7 @@ public class Post {
         .reportCount(0)
         .build();
 
-    PostLIke.builder().post(post).build();
+    PostLike.builder().post(post).build();
     post.mappingMember(member);
     post.mappingImage(image);
     return post;

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -76,6 +76,7 @@ public class Post {
         .reportCount(0)
         .build();
 
+    PostLIke.builder().post(post).build();
     post.mappingMember(member);
     post.mappingImage(image);
     return post;

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLIke.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLIke.java
@@ -1,0 +1,48 @@
+package com.kakaotech.team14backend.inner.post.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED) // 기본 생성자의 접근 권한을 protected로 제한
+public class PostLIke {
+
+  @Id
+  private Long postId;
+
+  @MapsId  // Post의 PK를 PostLike의 PK로 사용
+  @OneToOne
+  @JoinColumn(name = "postId")
+  private Post post;
+
+  @Column(nullable = false)
+  private Long likeCount;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt; // 생성일
+
+  @Column(nullable = false)
+  private LocalDateTime modifiedAt; // 수정일
+
+
+  @Builder
+  public PostLIke(Post post) {
+    this.post = post;
+    this.likeCount = 0L;
+    this.createdAt = LocalDateTime.now();
+    this.modifiedAt = LocalDateTime.now();
+  }
+
+  public void updateLikeCount(Long likeCount) {
+    this.likeCount = likeCount;
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLike.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLike.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED) // 기본 생성자의 접근 권한을 protected로 제한
-public class PostLIke {
+public class PostLike {
 
   @Id
   private Long postId;
@@ -35,7 +35,7 @@ public class PostLIke {
 
 
   @Builder
-  public PostLIke(Post post) {
+  public PostLike(Post post) {
     this.post = post;
     this.likeCount = 0L;
     this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SetPostLikeUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SetPostLikeUsecase.java
@@ -1,0 +1,44 @@
+package com.kakaotech.team14backend.inner.post.usecase;
+
+import com.kakaotech.team14backend.inner.post.repository.PostLikeRepository;
+import com.kakaotech.team14backend.outer.post.dto.setPostLikeDTO;
+import com.kakaotech.team14backend.outer.post.dto.setPostLikeResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SetPostLikeUsecase {
+
+  private final PostLikeRepository postLikeRepository;
+  private final RedisTemplate<String, Object> redisTemplate;
+  private static final String POST_LIKE_KEY_PREFIX = "POST_LIKE::";
+
+  public setPostLikeResponseDTO execute(setPostLikeDTO setPostLikeDTO) {
+    Long postId = setPostLikeDTO.postId();
+    Long memberId = setPostLikeDTO.memberId();
+
+    String key = getRedisKeyForPost(postId);
+    Boolean isLiked = getUserLikeStatus(key, memberId);
+
+    return toggleLikeStatus(key, memberId, isLiked);
+
+  }
+
+  private String getRedisKeyForPost(Long postId) {
+    return POST_LIKE_KEY_PREFIX + postId;
+  }
+
+  private boolean getUserLikeStatus(String key, Long memberId) {
+    return (boolean) redisTemplate.opsForHash().get(key, memberId);
+  }
+
+  private setPostLikeResponseDTO toggleLikeStatus(String key, Long memberId, Boolean isLiked) {
+    boolean newStatus = (isLiked == null || !isLiked);
+    redisTemplate.opsForHash().put(key, memberId, newStatus);
+    return new setPostLikeResponseDTO(newStatus);
+
+  }
+
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
@@ -8,6 +8,8 @@ import com.kakaotech.team14backend.outer.post.dto.GetPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.UploadPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.UploadPostRequestDTO;
+import com.kakaotech.team14backend.outer.post.dto.setPostLikeDTO;
+import com.kakaotech.team14backend.outer.post.dto.setPostLikeResponseDTO;
 import com.kakaotech.team14backend.outer.post.service.PostService;
 import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
@@ -69,5 +71,15 @@ public class PostController {
     return ApiResponseGenerator.success(getPostResponseDTO,HttpStatus.OK);
   }
 
+  @ApiOperation(value = "게시물 좋아요(추천 수)", notes = "게시물 좋아요를 누른다, 1인당 1개의 게시물에 1번만 좋아요를 누를 수 있다")
+  @PostMapping("/post/{postId}/like")
+  public ApiResponse<ApiResponse.CustomBody<setPostLikeResponseDTO>> setPostLike(@PathVariable("postId") Long postId){
+    Long memberId = 1L;
+
+    setPostLikeDTO setPostLikeDTO = new setPostLikeDTO(postId, memberId);
+    setPostLikeResponseDTO setPostLikeResponseDTO = postService.setPostLike(setPostLikeDTO);
+
+    return ApiResponseGenerator.success(setPostLikeResponseDTO,HttpStatus.OK);
+  }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
@@ -38,7 +38,7 @@ public class PostController {
     // todo: size와 lastPostId 예외처리, validation
 
     GetPostListResponseDTO getPostListResponseDTO = postService.getPostList(lastPostId, size);
-    return ApiResponseGenerator.success(getPostListResponseDTO, HttpStatus.CREATED);
+    return ApiResponseGenerator.success(getPostListResponseDTO, HttpStatus.OK);
   }
 
 

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/setPostLikeDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/setPostLikeDTO.java
@@ -1,0 +1,5 @@
+package com.kakaotech.team14backend.outer.post.dto;
+
+public record setPostLikeDTO(Long postId, Long memberId) {
+
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/setPostLikeResponseDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/setPostLikeResponseDTO.java
@@ -1,0 +1,5 @@
+package com.kakaotech.team14backend.outer.post.dto;
+
+public record setPostLikeResponseDTO(boolean isLiked) {
+
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
@@ -4,16 +4,19 @@ import com.kakaotech.team14backend.inner.image.model.Image;
 import com.kakaotech.team14backend.inner.image.usecase.CreateImageUsecase;
 import com.kakaotech.team14backend.inner.member.model.Member;
 import com.kakaotech.team14backend.inner.member.usecase.FindMemberUsecase;
-import com.kakaotech.team14backend.inner.post.usecase.FindPostListUsecase;
+import com.kakaotech.team14backend.inner.post.usecase.CreatePostUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.FindPopularPostUsecase;
+import com.kakaotech.team14backend.inner.post.usecase.FindPostListUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.FindPostUsecase;
+import com.kakaotech.team14backend.inner.post.usecase.SetPostLikeUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.UpdatePostViewCountUsecase;
 import com.kakaotech.team14backend.outer.post.dto.CreatePostDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.UploadPostDTO;
-import com.kakaotech.team14backend.inner.post.usecase.CreatePostUsecase;
+import com.kakaotech.team14backend.outer.post.dto.setPostLikeDTO;
+import com.kakaotech.team14backend.outer.post.dto.setPostLikeResponseDTO;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,6 +34,7 @@ public class PostService {
   private final FindPostListUsecase findPostListUsecase;
   private final FindPopularPostUsecase findPopularPostUsecase;
   private final UpdatePostViewCountUsecase updatePostViewCountUsecase;
+  private final SetPostLikeUsecase setPostLikeUsecase;
 
   @Transactional
   public void uploadPost(UploadPostDTO uploadPostDTO) throws IOException {
@@ -54,6 +58,11 @@ public class PostService {
     updatePostViewCountUsecase.execute(getPostDTO);
     GetPostResponseDTO getPostResponseDTO =findPopularPostUsecase.execute(getPostDTO);
     return getPostResponseDTO;
+  }
+
+  public setPostLikeResponseDTO setPostLike(setPostLikeDTO setPostLikeDTO) {
+
+    return setPostLikeUsecase.execute(setPostLikeDTO);
   }
 
 }

--- a/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
+++ b/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
@@ -52,7 +52,7 @@ public class PostControllerTest {
 
     System.out.println("findAllHomeFeed_Test : " + responseBody);
 
-    resultActions.andExpect(status().isCreated());
+    resultActions.andExpect(status().isOk());
     resultActions.andExpect(jsonPath("$.success").value(true));
     resultActions.andExpect(jsonPath("$.response").exists());
   }
@@ -69,7 +69,7 @@ public class PostControllerTest {
 
     System.out.println("findAllHomeFeedNoParam_Test : " + responseBody);
 
-    resultActions.andExpect(status().isCreated());
+    resultActions.andExpect(status().isOk());
     resultActions.andExpect(jsonPath("$.success").value(true));
     resultActions.andExpect(jsonPath("$.response").exists());
   }
@@ -107,7 +107,7 @@ public class PostControllerTest {
 
     System.out.println("findAllHomeFeedNoLastPostId_Test : " + responseBody);
 
-    resultActions.andExpect(status().isCreated());
+    resultActions.andExpect(status().isOk());
     resultActions.andExpect(jsonPath("$.success").value(true));
     resultActions.andExpect(jsonPath("$.response").exists());
   }


### PR DESCRIPTION
좋아요 수 전체 업데이트와 유저 별 포스트 좋아요 수 히스토리 관리 등은  좀 더 고려해보겠습니당

## 구현 된 기능
- Redis를 이용한 좋아요 상태 토글 로직 구현 (SetPostLikeUsecase)
- 좋아요 관련 레포지토리 추가 (PostLikeRepository)
- PostController에 좋아요 API 엔드포인트 추가

이슈 번호 : [#39](https://github.com/Step3-kakao-tech-campus/Team14_BE/issues/39)