### PR TITLE
fix : Post와 PostLike의 참조 관계 수정

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -55,6 +55,9 @@ public class Post {
   @Column(nullable = false)
   private Integer reportCount; // 제재 횟수
 
+  @OneToOne(mappedBy = "post", fetch = FetchType.LAZY)
+  private PostLike postLike;
+
   public void mappingMember(Member member) {
     this.member = member;
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLike.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLike.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.PROTECTED;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapsId;
@@ -19,8 +20,9 @@ public class PostLike {
   @Id
   private Long postId;
 
-  @MapsId  // Post의 PK를 PostLike의 PK로 사용
-  @OneToOne
+
+  @MapsId
+  @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "postId")
   private Post post;
 


### PR DESCRIPTION
1. Post에서 PostLike를 참조하는 일이 잦기 때문에 참조 관계를 수정하였습니다
2. PostLike의 PK는 그대로 @MapsId 어노테이션을 통해 postId로 유지합니다. 
    - Post를 조회 할 일은 현저히 적으나, 데이터 무결성과 명확한 관계를 위해 유지하였습니다
    - PostLike에 Post를 두는 이유 Post를 지우면, postId를 PostLike의 PK로 선정하는 별도의 로직을 만들어야 하기 때문입니다