### PR TITLE
feat: PostLikeHistory 엔티티 및 좋아요 이력 관리 유즈케이스 구현

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
@@ -65,6 +65,8 @@ public class Member {
   @Enumerated(EnumType.STRING)
   private Status userStatus; // 제재, 탈퇴, 정상 등등
 
+  @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+  private List<PostLikeHistory> postLikeHistories = new ArrayList<>();
 
   @Builder
   public Member(String userName, String kakaoId, String instaId, Role role, Long totalLike, Status userStatus) {
@@ -72,7 +74,7 @@ public class Member {
     this.kakaoId = kakaoId;
     this.instaId = instaId;
     this.role = role;
-    this.totalLike= totalLike;
+    this.totalLike = totalLike;
     this.userStatus = userStatus;
   }
 

--- a/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
@@ -1,25 +1,26 @@
 package com.kakaotech.team14backend.inner.member.model;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.inner.post.model.PostLikeHistory;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
-import javax.persistence.*;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
-import static lombok.AccessLevel.PROTECTED;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
 
 
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -61,6 +61,9 @@ public class Post {
   @Column(nullable = false)
   private Integer reportCount; // 제재 횟수
 
+  @OneToOne(mappedBy = "post", fetch = FetchType.LAZY)
+  private PostLike postLike;
+
   public void mappingMember(Member member) {
     this.member = member;
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -61,9 +61,6 @@ public class Post {
   @Column(nullable = false)
   private Integer reportCount; // 제재 횟수
 
-  @OneToOne(mappedBy = "post", fetch = FetchType.LAZY)
-  private PostLike postLike;
-
   public void mappingMember(Member member) {
     this.member = member;
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -4,11 +4,19 @@ import static lombok.AccessLevel.PROTECTED;
 
 import com.kakaotech.team14backend.inner.image.model.Image;
 import com.kakaotech.team14backend.inner.member.model.Member;
-import javax.persistence.*;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.Period;
-
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -61,6 +69,8 @@ public class Post {
   @Column(nullable = false)
   private Integer reportCount; // 제재 횟수
 
+  @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+  private List<PostLikeHistory> postLikeHistories;
   public void mappingMember(Member member) {
     this.member = member;
   }
@@ -69,12 +79,13 @@ public class Post {
     this.image = image;
   }
 
-  public void mappingPostLike(PostLike postLike){
+  public void mappingPostLike(PostLike postLike) {
     postLike.mappingPost(this);
     this.postLike = postLike;
   }
 
-  public static Post createPost(Member member, Image image, PostLike postLike, String nickname, Boolean published,
+  public static Post createPost(Member member, Image image, PostLike postLike, String nickname,
+      Boolean published,
       String hashtag, String university) {
 
     Post post = Post.builder()
@@ -106,17 +117,17 @@ public class Post {
     this.reportCount = reportCount;
   }
 
-  public void updateViewCount(Long viewCount){
+  public void updateViewCount(Long viewCount) {
     this.viewCount = viewCount;
   }
 
-  public long measurePostAge(){
+  public long measurePostAge() {
     Instant now = Instant.now();
     int time = now.compareTo(this.createdAt);
-    return time/5;
+    return time / 5;
   }
 
-  public void updatePopularity(long likeCount, long postAge){
+  public void updatePopularity(long likeCount, long postAge) {
     this.popularity = (likeCount * 100 + this.viewCount * 50) / (postAge + 1L);
   }
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLike.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLike.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapsId;
@@ -25,9 +24,8 @@ public class PostLike {
   @Id
   private Long postId;
 
-
-  @MapsId
-  @OneToOne(fetch = FetchType.LAZY)
+  @MapsId  // Post의 PK를 PostLike의 PK로 사용
+  @OneToOne
   @JoinColumn(name = "postId")
   private Post post;
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLike.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLike.java
@@ -25,9 +25,10 @@ public class PostLike {
   @Id
   private Long postId;
 
-  @MapsId  // Post의 PK를 PostLike의 PK로 사용
-  @OneToOne
-  @JoinColumn(name = "postLikeId")
+
+  @MapsId
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "postId")
   private Post post;
 
   @Column(nullable = false)

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLikeHistory.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/PostLikeHistory.java
@@ -1,0 +1,44 @@
+package com.kakaotech.team14backend.inner.post.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import com.kakaotech.team14backend.inner.member.model.Member;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class PostLikeHistory {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long postLikeHistoryId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "memberId")
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "postId")
+  private Post post;
+
+
+  public static PostLikeHistory createPostLikeHistory(Member member, Post post) {
+    return PostLikeHistory.builder().member(member).post(post).build();
+  }
+
+  @Builder
+  public PostLikeHistory(Member member, Post post) {
+    this.member = member;
+    this.post = post;
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/inner/post/repository/PostLikeHistoryRepository.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/repository/PostLikeHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.kakaotech.team14backend.inner.post.repository;
+
+import com.kakaotech.team14backend.inner.post.model.PostLikeHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeHistoryRepository extends JpaRepository<PostLikeHistory, Long> {
+
+}

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/CreatePostLikeHistoryUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/CreatePostLikeHistoryUsecase.java
@@ -1,0 +1,30 @@
+package com.kakaotech.team14backend.inner.post.usecase;
+
+import com.kakaotech.team14backend.inner.member.model.Member;
+import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.inner.post.model.PostLikeHistory;
+import com.kakaotech.team14backend.inner.post.repository.PostLikeHistoryRepository;
+import com.kakaotech.team14backend.outer.post.dto.GetPostLikeHistoryDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CreatePostLikeHistoryUsecase {
+
+  private final PostLikeHistoryRepository postLikeHistoryRepository;
+
+  // Post에 좋아요가 추가 되고, Redis에서 스케줄링 되어, DB에 저장 되는 순간에 PostLikeHistory를 생성한다.
+  // 만약, 추후 좋아요가 취소 된다면 PostLikeHistory를 삭제한다.
+
+
+  @Transactional
+  public PostLikeHistory execute(GetPostLikeHistoryDTO getPostLikeHistoryDTO) {
+    Member member = getPostLikeHistoryDTO.member();
+    Post post = getPostLikeHistoryDTO.post();
+    PostLikeHistory postLikeHistory = PostLikeHistory.createPostLikeHistory(member, post);
+    return postLikeHistoryRepository.save(postLikeHistory);
+
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostLikeHistoryDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostLikeHistoryDTO.java
@@ -1,0 +1,8 @@
+package com.kakaotech.team14backend.outer.post.dto;
+
+import com.kakaotech.team14backend.inner.member.model.Member;
+import com.kakaotech.team14backend.inner.post.model.Post;
+
+public record GetPostLikeHistoryDTO(Member member, Post post) {
+
+}


### PR DESCRIPTION

새로운 엔티티인 `PostLikeHistory`를 추가하여 사용자의 좋아요 이력을 관리하게 되었습니다. 
이 엔티티는 `Member`와 `Post` 엔티티와 다대일 관계를 형성하여 어떤 사용자가 어떤 게시물에 좋아요를 눌렀는지의 이력을 저장하게 됩니다. 

이는 추후 좋아요 취소 시 이력을 삭제하기 위한 목적으로 사용됩니다.

`CreatePostLikeHistoryUsecase` 클래스를 통해 좋아요가 추가되고, Redis 스케줄링을 통해 DB에 저장되는 순간에 `PostLikeHistory`를 생성하도록 구현하였습니다. 
이 유즈케이스는 `getPostLikeHistoryDTO`를 인자로 받아서, 해당 데이터를 기반으로 `PostLikeHistory` 엔티티를 생성하고 저장하게 됩니다.

또한, 좋아요 취소 시 `PostLikeHistory`를 삭제하는 기능은 추후 구현 예정입니다.
