### PR TITLE
 인기도 업데이트 스케줄링 테스트

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -124,11 +124,12 @@ public class Post {
   public long measurePostAge() {
     Instant now = Instant.now();
     int time = now.compareTo(this.createdAt);
-    return time / 5;
+    return time < 5 ? 1 : time / 5;
   }
 
-  public void updatePopularity(long likeCount, long postAge) {
-    this.popularity = (likeCount * 100 + this.viewCount * 50) / (postAge + 1L);
+  public void updatePopularity(long likeCount, long postAge){
+    long popularity = (likeCount + this.viewCount) / postAge;
+    this.popularity = Long.valueOf(popularity);
   }
 
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -36,7 +36,6 @@ public class Post {
   @JoinColumn(name = "memberId")
   private Member member; // 유저 아이디
 
-
   @OneToOne
   @JoinColumn(name = "imageId")
   private Image image; // 사진 ID
@@ -63,7 +62,7 @@ public class Post {
   @Column(nullable = true)
   private Long viewCount; // 조회수
 
-  @Column(nullable = false)
+  @Column(nullable = true)
   private Long popularity; // 인기도 값
 
   @Column(nullable = false)
@@ -124,7 +123,7 @@ public class Post {
   public long measurePostAge() {
     Instant now = Instant.now();
     int time = now.compareTo(this.createdAt);
-    return time < 5 ? 1 : time / 5;
+    return  time < 5 ? 1 : time / 5;
   }
 
   public void updatePopularity(long likeCount, long postAge){

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecase.java
@@ -17,7 +17,10 @@ public class SchedulePostPopularityUsecase {
   @Transactional
   @Scheduled(initialDelayString = "${schedules.initialDelay}",fixedDelayString = "${schedules.fixedDelay}")
   public void execute() {
-    postRepository.findAll().stream().forEach(post -> post.updatePopularity(post.getPostLike().getLikeCount(),post.measurePostAge()));
+    postRepository.findAll().stream().forEach(post -> {
+      Long likeCount = post.getPostLike().getLikeCount();
+      long postAge = post.measurePostAge();
+      post.updatePopularity(likeCount.longValue(), postAge);
+    });
   }
-
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecase.java
@@ -1,13 +1,11 @@
 package com.kakaotech.team14backend.inner.post.usecase;
 
-import com.kakaotech.team14backend.inner.post.repository.PostLikeRepository;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.ZoneId;
 
 
 @Component
@@ -15,10 +13,9 @@ import java.time.ZoneId;
 public class SchedulePostPopularityUsecase {
 
   private final PostRepository postRepository;
-  private final PostLikeRepository postLikeRepository;
 
   @Transactional
-  @Scheduled(initialDelay = 600000,fixedDelay = 600000)
+  @Scheduled(initialDelayString = "${schedules.initialDelay}",fixedDelayString = "${schedules.fixedDelay}")
   public void execute() {
     postRepository.findAll().stream().forEach(post -> post.updatePopularity(post.getPostLike().getLikeCount(),post.measurePostAge()));
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecase.java
@@ -1,26 +1,19 @@
 package com.kakaotech.team14backend.inner.post.usecase;
 
-import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
 
 
 @Component
 @RequiredArgsConstructor
 public class SchedulePostPopularityUsecase {
 
-  private final PostRepository postRepository;
+  private final UpdatePostPopularityUsecase updatePostPopularityUsecase;
 
-  @Transactional
   @Scheduled(initialDelayString = "${schedules.initialDelay}",fixedDelayString = "${schedules.fixedDelay}")
   public void execute() {
-    postRepository.findAll().stream().forEach(post -> {
-      Long likeCount = post.getPostLike().getLikeCount();
-      long postAge = post.measurePostAge();
-      post.updatePopularity(likeCount.longValue(), postAge);
-    });
+    updatePostPopularityUsecase.execute();
   }
+
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostViewCountUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostViewCountUsecase.java
@@ -23,7 +23,7 @@ public class SchedulePostViewCountUsecase {
   private final PostRepository postRepository;
 
   @Transactional
-  @Scheduled(initialDelay = 600000,fixedDelay = 600000)
+  @Scheduled(initialDelayString = "${schedules.initialDelay}",fixedDelayString = "${schedules.fixedDelay}")
   public void execute() {
     Set<String> keys = redisTemplate.keys("viewCnt*");
     for(String key : keys){

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
@@ -1,0 +1,27 @@
+package com.kakaotech.team14backend.inner.post.usecase;
+
+import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.inner.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UpdatePostPopularityUsecase {
+
+  private final PostRepository postRepository;
+
+  @Transactional
+  public void execute() {
+    List<Post> posts = postRepository.findAll();
+    for (Post post : posts) {
+      Long likeCount = post.getPostLike().getLikeCount();
+      long postAge = post.measurePostAge();
+      post.updatePopularity(likeCount.longValue(), postAge);
+      postRepository.save(post);
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,8 @@ spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.h2.console.enabled=true
 
+schedules.fixedDelay=600000
+schedules.initialDelay=600000
 
 spring.security.oauth2.client.registration.kakao.client-id=7173ac3049183122f6704ddf9b43425d
 spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecaseTest.java
@@ -9,13 +9,12 @@ import com.kakaotech.team14backend.inner.member.repository.MemberRepository;
 import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.model.PostLike;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-
+import javax.persistence.EntityManager;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
@@ -39,6 +38,9 @@ class SchedulePostPopularityUsecaseTest {
   @Autowired
   private ImageRepository imageRepository;
 
+  @Autowired
+  private EntityManager em;
+
 
   @BeforeEach
   void setUp() {
@@ -51,26 +53,41 @@ class SchedulePostPopularityUsecaseTest {
 
     Post post = Post.createPost(member, image,postLike, "Sonny", true, "#hashTag", "university4");
     postRepository.save(post);
+  }
+
+  @Test
+  void execute_schedule() {
+
+    await()
+        .atMost(Duration.ofMinutes(10L)) // 최대 대기 시간
+        .untilAsserted(() -> {
+          Post post = postRepository.findById(1L).get();
+          post.updateViewCount(500L);
+          postRepository.save(post);
+
+          try {
+            Thread.sleep(1500);
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+
+          schedulePostPopularityUsecase.execute();
+          Post updatedPost = postRepository.findById(1L).get();
+          Assertions.assertThat(updatedPost.getPopularity()).isEqualTo(500);
+
+        });
 
   }
 
   @Test
   void execute() {
-    Callable<Boolean> popularirity = (Callable<Boolean>) () -> {
       Post post = postRepository.findById(1L).get();
       post.updateViewCount(500L);
       postRepository.save(post);
 
       schedulePostPopularityUsecase.execute();
-
       Post updatedPost = postRepository.findById(1L).get();
-
-      Assertions.assertEquals(updatedPost.getPopularity() !=0,true);
-      return true;
-    };
-    await()
-        .atMost(Duration.ofMinutes(3L)) // 최대 대기 시간
-        .until(popularirity);
+      Assertions.assertThat(updatedPost.getPopularity()).isEqualTo(500);
   }
 
 }

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecaseTest.java
@@ -8,7 +8,6 @@ import com.kakaotech.team14backend.inner.member.model.Status;
 import com.kakaotech.team14backend.inner.member.repository.MemberRepository;
 import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.model.PostLike;
-import com.kakaotech.team14backend.inner.post.repository.PostLikeRepository;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,10 @@ import java.util.concurrent.Callable;
 
 import static org.awaitility.Awaitility.await;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+    "schedules.initialDelay:1000"
+    ,"schedules.fixedDelay:1000"
+})
 class SchedulePostPopularityUsecaseTest {
 
   @Autowired
@@ -66,8 +68,7 @@ class SchedulePostPopularityUsecaseTest {
       return true;
     };
     await()
-        .atMost(Duration.ofMinutes(21L)) // 최대 대기 시간
-        .pollDelay(Duration.ofMinutes(20L)) // Awaitility가 첫 번째로 결과를 확인하기 전에 기다릴 지연 시간
+        .atMost(Duration.ofMinutes(1L)) // 최대 대기 시간
         .until(popularirity);
 
   }

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SchedulePostPopularityUsecaseTest.java
@@ -9,6 +9,7 @@ import com.kakaotech.team14backend.inner.member.repository.MemberRepository;
 import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.model.PostLike;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,19 +58,19 @@ class SchedulePostPopularityUsecaseTest {
   void execute() {
     Callable<Boolean> popularirity = (Callable<Boolean>) () -> {
       Post post = postRepository.findById(1L).get();
-      post.updateViewCount(10L);
+      post.updateViewCount(500L);
       postRepository.save(post);
 
       schedulePostPopularityUsecase.execute();
 
-      if(post.getPopularity() !=0){
-        return false;
-      }
+      Post updatedPost = postRepository.findById(1L).get();
+
+      Assertions.assertEquals(updatedPost.getPopularity() !=0,true);
       return true;
     };
     await()
-        .atMost(Duration.ofMinutes(1L)) // 최대 대기 시간
+        .atMost(Duration.ofMinutes(3L)) // 최대 대기 시간
         .until(popularirity);
-
   }
+
 }


### PR DESCRIPTION
스케줄링과 트랜잭션을 담당하는 클래스를 분리하고, 인기도 업데이트 스케줄링 테스트하는 코드를 작성하였습니다.

## Commit 요약

### test : 스케줄러 테스트 시 실제 애플리케이션 작동시 스케줄링 지연 시간과 반복 주기를 1초로 변경

### feat : 어떤 상황에서도 게시글 나이가 1 이상이 되도록 변경

### feat : @transactional 과 @Scheduled 함께 사용 문제로 인한 문제 해결


### 관련 이슈:  #38 