### PR TITLE
likeCount 최소 기능 구현 완료

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostLikeCountUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostLikeCountUsecase.java
@@ -22,16 +22,17 @@ public class UpdatePostLikeCountUsecase {
     boolean isLiked = getPostLikeCountDTO.isLiked();
 
     PostLikeCount postLikeCount = postLikeCountRepository.findByPostId(postId);
+    Long likeCount = postLikeCount.getLikeCount();
+    
+//    Long cachedCount = redisTemplate.opsForValue().get(POST_LIKE_KEY_PREFIX + postId);
 
-    Long cachedCount = redisTemplate.opsForValue().get(POST_LIKE_KEY_PREFIX + postId);
-
-    if (cachedCount == null) {
-      cachedCount = postLikeCount.getLikeCount();
-    }
-    cachedCount = isLiked ? cachedCount + 1 : cachedCount - 1;
-    redisTemplate.opsForValue().set(POST_LIKE_KEY_PREFIX + postId, cachedCount);
-
-    postLikeCount.updateLikeCount(cachedCount);
+//    if (cachedCount == null) {
+//      cachedCount = postLikeCount.getLikeCount();
+//    }
+//    cachedCount = isLiked ? cachedCount + 1 : cachedCount - 1;
+//    redisTemplate.opsForValue().set(POST_LIKE_KEY_PREFIX + postId, cachedCount);
+    likeCount = isLiked ? likeCount + 1 : likeCount - 1;
+    postLikeCount.updateLikeCount(likeCount);
     postLikeCountRepository.save(postLikeCount);
   }
 

--- a/src/main/resources/db/teardown.sql
+++ b/src/main/resources/db/teardown.sql
@@ -8,9 +8,9 @@ SET REFERENTIAL_INTEGRITY TRUE;
 -- Member Table
 INSERT INTO member (created_at, insta_id, kakao_id, total_like, updated_at, user_name, user_status,
                     role)
-VALUES (NOW(), 'insta1', 'kakao1', 10, NOW(), 'user1', 'ACTIVE', 'ROLE_BEGINNER'),
-       (NOW(), 'insta2', 'kakao2', 20, NOW(), 'user2', 'ACTIVE', 'ROLE_BEGINNER'),
-       (NOW(), 'insta3', 'kakao3', 30, NOW(), 'user3', 'INACTIVE', 'ROLE_BEGINNER');
+VALUES (NOW(), 'insta1', 'kakao1', 10, NOW(), 'user1', 'STATUS_ACTIVE', 'ROLE_BEGINNER'),
+       (NOW(), 'insta2', 'kakao2', 20, NOW(), 'user2', 'STATUS_ACTIVE', 'ROLE_BEGINNER'),
+       (NOW(), 'insta3', 'kakao3', 30, NOW(), 'user3', 'STATUS_DORMANT', 'ROLE_BEGINNER');
 
 -- Image Table
 INSERT INTO image (created_at, image_uri)

--- a/src/main/resources/db/teardown.sql
+++ b/src/main/resources/db/teardown.sql
@@ -2,7 +2,7 @@ SET REFERENTIAL_INTEGRITY FALSE;
 TRUNCATE TABLE member;
 TRUNCATE TABLE image;
 TRUNCATE TABLE post;
-
+TRUNCATE TABLE post_like_count;
 SET REFERENTIAL_INTEGRITY TRUE;
 
 -- Member Table
@@ -25,48 +25,32 @@ VALUES (NOW(), 'image_uri1'),
        (NOW(), 'image_uri9'),
        (NOW(), 'image_uri10');
 -- Post Table
-INSERT INTO post (created_at, nickname, popularity, published, report_count, university, view_count, post_point,
+INSERT INTO post (created_at, nickname, popularity, published, report_count, university, view_count,
+                  post_point,
                   image_id, member_id, hashtag)
 VALUES (NOW(), 'nickname1', 100, true, 0, 'university1', 1000, 400, 1, 1, '#hashtag1'),
-       (NOW(), 'nickname2', 200, true, 1, 'university2', 2000, 400,2, 2, '#hashtag2'),
-       (NOW(), 'nickname3', 300, false, 2, 'university3', 3000, 400,3, 3, '#hashtag3'),
-       (NOW(), 'nickname4', 400, true, 3, 'university4', 4000, 400,4, 1, '#hashtag4'),
-       (NOW(), 'nickname5', 500, false, 4, 'university5', 5000, 400,5, 2, '#hashtag5'),
-       (NOW(), 'nickname6', 600, true, 5, 'university6', 6000, 400,6, 3, '#hashtag6'),
-       (NOW(), 'nickname7', 700, false, 6, 'university7', 7000, 400,7, 1, '#hashtag7'),
-       (NOW(), 'nickname8', 800, true, 7, 'university8', 8000, 400,8, 2, '#hashtag8'),
-       (NOW(), 'nickname9', 900, false, 8, 'university9', 9000, 400,9, 3, '#hashtag9'),
-       (NOW(), 'nickname10', 1000, true, 9, 'university10', 10000, 400,10, 1, '#hashtag10'),
-       (NOW(), 'nickname11', 100, true, 0, 'university1', 1000, 400,1, 1, '#hashtag1'),
-       (NOW(), 'nickname12', 200, true, 1, 'university2', 2000, 400,2, 2, '#hashtag2'),
-       (NOW(), 'nickname13', 300, false, 2, 'university3', 3000, 400,3, 3, '#hashtag3'),
-       (NOW(), 'nickname14', 400, true, 3, 'university4', 4000, 400,4, 1, '#hashtag4'),
-       (NOW(), 'nickname15', 500, false, 4, 'university5', 5000, 400,5, 2, '#hashtag5'),
-       (NOW(), 'nickname16', 600, true, 5, 'university6', 6000, 400,6, 3, '#hashtag6'),
-       (NOW(), 'nickname17', 700, false, 6, 'university7', 7000, 400,7, 1, '#hashtag7'),
-       (NOW(), 'nickname18', 800, true, 7, 'university8', 8000, 400,8, 2, '#hashtag8'),
-       (NOW(), 'nickname19', 900, false, 8, 'university9', 9000, 400,9, 3, '#hashtag9'),
-       (NOW(), 'nickname20', 1000, true, 9, 'university10', 10000, 400,10, 1, '#hashtag10');
+       (NOW(), 'nickname2', 200, true, 1, 'university2', 2000, 400, 2, 2, '#hashtag2'),
+       (NOW(), 'nickname3', 300, false, 2, 'university3', 3000, 400, 3, 3, '#hashtag3'),
+       (NOW(), 'nickname4', 400, true, 3, 'university4', 4000, 400, 4, 1, '#hashtag4'),
+       (NOW(), 'nickname5', 500, false, 4, 'university5', 5000, 400, 5, 2, '#hashtag5'),
+       (NOW(), 'nickname6', 600, true, 5, 'university6', 6000, 400, 6, 3, '#hashtag6'),
+       (NOW(), 'nickname7', 700, false, 6, 'university7', 7000, 400, 7, 1, '#hashtag7'),
+       (NOW(), 'nickname8', 800, true, 7, 'university8', 8000, 400, 8, 2, '#hashtag8'),
+       (NOW(), 'nickname9', 900, false, 8, 'university9', 9000, 400, 9, 3, '#hashtag9'),
+       (NOW(), 'nickname10', 1000, true, 9, 'university10', 10000, 400, 10, 1, '#hashtag10'),
+       (NOW(), 'nickname11', 100, true, 0, 'university1', 1000, 400, 1, 1, '#hashtag1'),
+       (NOW(), 'nickname12', 200, true, 1, 'university2', 2000, 400, 2, 2, '#hashtag2'),
+       (NOW(), 'nickname13', 300, false, 2, 'university3', 3000, 400, 3, 3, '#hashtag3'),
+       (NOW(), 'nickname14', 400, true, 3, 'university4', 4000, 400, 4, 1, '#hashtag4'),
+       (NOW(), 'nickname15', 500, false, 4, 'university5', 5000, 400, 5, 2, '#hashtag5'),
+       (NOW(), 'nickname16', 600, true, 5, 'university6', 6000, 400, 6, 3, '#hashtag6'),
+       (NOW(), 'nickname17', 700, false, 6, 'university7', 7000, 400, 7, 1, '#hashtag7'),
+       (NOW(), 'nickname18', 800, true, 7, 'university8', 8000, 400, 8, 2, '#hashtag8'),
+       (NOW(), 'nickname19', 900, false, 8, 'university9', 9000, 400, 9, 3, '#hashtag9'),
+       (NOW(), 'nickname20', 1000, true, 9, 'university10', 10000, 400, 10, 1, '#hashtag10');
 
 -- PostLikeCount Table
 INSERT INTO post_like_count (post_id, like_count, created_at, modified_at)
-VALUES (1, 0, NOW(), NOW()),
-       (2, 0, NOW(), NOW()),
-       (3, 0, NOW(), NOW()),
-       (4, 0, NOW(), NOW()),
-       (5, 0, NOW(), NOW()),
-       (6, 0, NOW(), NOW()),
-       (7, 0, NOW(), NOW()),
-       (8, 0, NOW(), NOW()),
-       (9, 0, NOW(), NOW()),
-       (10, 0, NOW(), NOW()),
-       (11, 0, NOW(), NOW()),
-       (12, 0, NOW(), NOW()),
-       (13, 0, NOW(), NOW()),
-       (14, 0, NOW(), NOW()),
-       (15, 0, NOW(), NOW()),
-       (16, 0, NOW(), NOW()),
-       (17, 0, NOW(), NOW()),
-       (18, 0, NOW(), NOW()),
-       (19, 0, NOW(), NOW()),
-       (20, 0, NOW(), NOW());
+SELECT post_id, 0, NOW(), NOW()
+FROM post
+WHERE post_id BETWEEN 1 AND 20;

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostLikeCountUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostLikeCountUsecaseTest.java
@@ -1,24 +1,19 @@
 package com.kakaotech.team14backend.inner.post.usecase;
 
-import com.kakaotech.team14backend.inner.image.model.Image;
 import com.kakaotech.team14backend.inner.image.repository.ImageRepository;
-import com.kakaotech.team14backend.inner.member.model.Member;
-import com.kakaotech.team14backend.inner.member.model.Role;
-import com.kakaotech.team14backend.inner.member.model.Status;
 import com.kakaotech.team14backend.inner.member.repository.MemberRepository;
-import com.kakaotech.team14backend.inner.post.model.Post;
-import com.kakaotech.team14backend.inner.post.model.PostLikeCount;
 import com.kakaotech.team14backend.inner.post.repository.PostLikeCountRepository;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import com.kakaotech.team14backend.outer.post.dto.GetPostLikeCountDTO;
 import com.kakaotech.team14backend.outer.post.dto.SetPostLikeDTO;
 import com.kakaotech.team14backend.outer.post.dto.SetPostLikeResponseDTO;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 
+@Sql("classpath:db/teardown.sql")
 @SpringBootTest
 public class UpdatePostLikeCountUsecaseTest {
 
@@ -39,20 +34,6 @@ public class UpdatePostLikeCountUsecaseTest {
   @Autowired
   private ImageRepository imageRepository;
 
-  @BeforeEach
-  void setup() {
-    Member member = new Member("sonny", "sonny1234", "asdf324", Role.ROLE_BEGINNER, 0L,
-        Status.STATUS_ACTIVE);
-    memberRepository.save(member);
-
-    Image image = new Image("/image/firstPhoto");
-    imageRepository.save(image);
-    PostLikeCount postLikeCount = PostLikeCount.createPostLikeCount();
-
-    Post post = Post.createPost(member, image, postLikeCount, "대선대선", true, "#가자", "전남대학교");
-    postRepository.save(post);
-  }
-
   @Test
   void execute() {
     //given
@@ -67,6 +48,6 @@ public class UpdatePostLikeCountUsecaseTest {
 
     // when
     Assertions.assertThat(postRepository.findById(postId).get().getPostLikeCount().getLikeCount())
-        .isGreaterThan(0L);
+        .isEqualTo(1L);
   }
 }

--- a/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
+++ b/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
@@ -28,72 +28,72 @@ public class PostControllerTest {
   private MockMvc mockMvc;
 
 
-//  @DisplayName("홈 피드를 조회한다 - 정상 파라미터")
-//  @Test
-//  void findAllHomeFeed_Test() throws Exception {
-//
+  @DisplayName("홈 피드를 조회한다 - 정상 파라미터")
+  @Test
+  void findAllHomeFeed_Test() throws Exception {
+
+    ResultActions resultActions = mockMvc.perform(
+        get("/api/post").param("lastPostId", "0").param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON));
+
+    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+
+    System.out.println("findAllHomeFeed_Test : " + responseBody);
+
+    resultActions.andExpect(status().isOk());
+    resultActions.andExpect(jsonPath("$.success").value(true));
+    resultActions.andExpect(jsonPath("$.response").exists());
+  }
+
+  @DisplayName("처음 홈피드를 조회한다 - 파라미터 없음")
+  @Test
+  void findAllHomeFeedNoParam_Test() throws Exception {
+    ResultActions resultActions = mockMvc.perform(
+        get("/api/post").param("size", "10").contentType(MediaType.APPLICATION_JSON));
+
+    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+
+    System.out.println("findAllHomeFeedNoParam_Test : " + responseBody);
+
+    resultActions.andExpect(status().isOk());
+    resultActions.andExpect(jsonPath("$.success").value(true));
+    resultActions.andExpect(jsonPath("$.response").exists());
+  }
+
+  @DisplayName("홈 피드를 조회한다 - 잘못된 파라미터")
+  @Test
+  void findAllHomeFeedWrongParam_Test() throws Exception {
+
 //    ResultActions resultActions = mockMvc.perform(
-//        get("/api/post").param("lastPostId", "0").param("size", "10")
+//        get("/api/post")
+//            .param("lastPostId", "0")
+//            .param("size", "-1")
 //            .contentType(MediaType.APPLICATION_JSON));
 //
 //    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
 //
-//    System.out.println("findAllHomeFeed_Test : " + responseBody);
+//    System.out.println("findAllHomeFeedWrongParam_Test : " + responseBody);
 //
-//    resultActions.andExpect(status().isOk());
-//    resultActions.andExpect(jsonPath("$.success").value(true));
-//    resultActions.andExpect(jsonPath("$.response").exists());
-//  }
-//
-//  @DisplayName("처음 홈피드를 조회한다 - 파라미터 없음")
-//  @Test
-//  void findAllHomeFeedNoParam_Test() throws Exception {
-//    ResultActions resultActions = mockMvc.perform(
-//        get("/api/post").param("size", "10").contentType(MediaType.APPLICATION_JSON));
-//
-//    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//
-//    System.out.println("findAllHomeFeedNoParam_Test : " + responseBody);
-//
-//    resultActions.andExpect(status().isOk());
-//    resultActions.andExpect(jsonPath("$.success").value(true));
-//    resultActions.andExpect(jsonPath("$.response").exists());
-//  }
-//
-//  @DisplayName("홈 피드를 조회한다 - 잘못된 파라미터")
-//  @Test
-//  void findAllHomeFeedWrongParam_Test() throws Exception {
-//
-////    ResultActions resultActions = mockMvc.perform(
-////        get("/api/post")
-////            .param("lastPostId", "0")
-////            .param("size", "-1")
-////            .contentType(MediaType.APPLICATION_JSON));
-////
-////    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-////
-////    System.out.println("findAllHomeFeedWrongParam_Test : " + responseBody);
-////
-////    resultActions.andExpect(status().isBadRequest());
-////    resultActions.andExpect(jsonPath("$.success").value(false));
-////    resultActions.andExpect(jsonPath("$.response").doesNotExist());
-//  }
-//
-//  @DisplayName("홈 피드를 조회한다 - 마지막 게시물 아이디가 없을 때")
-//  @Test
-//  void findAllHomeFeedNoLastPostId_Test() throws Exception {
-//
-//    ResultActions resultActions = mockMvc.perform(
-//        get("/api/post").param("lastPostId", "15").param("size", "10")
-//            .contentType(MediaType.APPLICATION_JSON));
-//
-//    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//
-//    System.out.println("findAllHomeFeedNoLastPostId_Test : " + responseBody);
-//
-//    resultActions.andExpect(status().isOk());
-//    resultActions.andExpect(jsonPath("$.success").value(true));
-//    resultActions.andExpect(jsonPath("$.response").exists());
-//  }
+//    resultActions.andExpect(status().isBadRequest());
+//    resultActions.andExpect(jsonPath("$.success").value(false));
+//    resultActions.andExpect(jsonPath("$.response").doesNotExist());
+  }
+
+  @DisplayName("홈 피드를 조회한다 - 마지막 게시물 아이디가 없을 때")
+  @Test
+  void findAllHomeFeedNoLastPostId_Test() throws Exception {
+
+    ResultActions resultActions = mockMvc.perform(
+        get("/api/post").param("lastPostId", "15").param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON));
+
+    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+
+    System.out.println("findAllHomeFeedNoLastPostId_Test : " + responseBody);
+
+    resultActions.andExpect(status().isOk());
+    resultActions.andExpect(jsonPath("$.success").value(true));
+    resultActions.andExpect(jsonPath("$.response").exists());
+  }
 
 }


### PR DESCRIPTION
- 기존의 레디스 캐시에서 좋아요 수를 가져오는 부분, 주석 처리되어 있고, 대신 데이터베이스에서 직접 좋아요 수를 가져와 업데이트합니다.
## Hot fix 
- teardown.SQL 파일의 member 상태 enum이 반영
- 테스트에서 teardown.SQL 터지던 문제가 해결 (likeCount 테이블 초기화를 하지 않아서 발생한 문제)

### 문제 해결 방법

SQL 스크립트는 데이터를 리셋하고 테이블 간의 관계를 유지하기 위해 참조 무결성을 일시적으로 비활성화/활성화합니다. 
이러한 방식으로 테이블의 데이터를 초기 상태로 리셋하고, 이전에 발생했던 유일성 또는 기본 키 제약 조건 위반 문제를 해결하였습니다