### PR TITLE
전역 예외 핸들러 구현 및 게시물 조회 API 예외 처리 개선

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/exception/Exception400.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/Exception400.java
@@ -1,0 +1,17 @@
+package com.kakaotech.team14backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// 유효성 검사 실패, 잘못된 파라미터 요청
+@Getter
+public class Exception400 extends RuntimeException {
+
+  public Exception400(String message) {
+    super(message);
+  }
+
+  public HttpStatus status() {
+    return HttpStatus.BAD_REQUEST;
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/exception/Exception401.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/Exception401.java
@@ -1,0 +1,17 @@
+package com.kakaotech.team14backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// 인증 안됨
+@Getter
+public class Exception401 extends RuntimeException {
+
+  public Exception401(String message) {
+    super(message);
+  }
+
+  public HttpStatus status() {
+    return HttpStatus.UNAUTHORIZED;
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/exception/Exception403.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/Exception403.java
@@ -1,0 +1,17 @@
+package com.kakaotech.team14backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// 권한 없음
+@Getter
+public class Exception403 extends RuntimeException {
+
+  public Exception403(String message) {
+    super(message);
+  }
+
+  public HttpStatus status() {
+    return HttpStatus.FORBIDDEN;
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/exception/Exception404.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/Exception404.java
@@ -1,0 +1,16 @@
+package com.kakaotech.team14backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class Exception404 extends RuntimeException {
+
+  public Exception404(String message) {
+    super(message);
+  }
+
+  public HttpStatus status() {
+    return HttpStatus.NOT_FOUND;
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/exception/Exception500.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/Exception500.java
@@ -1,0 +1,17 @@
+package com.kakaotech.team14backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// 서버 에러
+@Getter
+public class Exception500 extends RuntimeException {
+
+  public Exception500(String message) {
+    super(message);
+  }
+
+  public HttpStatus status() {
+    return HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.kakaotech.team14backend.exception;
+
+import com.kakaotech.team14backend.common.ApiResponse;
+import com.kakaotech.team14backend.common.ApiResponseGenerator;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  private static final String EXCEPTION_400_CODE = "400";
+  private static final String EXCEPTION_401_CODE = "401";
+  private static final String EXCEPTION_403_CODE = "403";
+  private static final String EXCEPTION_404_CODE = "404";
+  private static final String EXCEPTION_500_CODE = "500";
+
+  @ExceptionHandler(Exception400.class)
+  public ApiResponse<ApiResponse.CustomBody> handleException400(Exception400 e) {
+    return ApiResponseGenerator.fail(EXCEPTION_400_CODE, e.getMessage(), e.status());
+  }
+
+  @ExceptionHandler(Exception401.class)
+  public ApiResponse<ApiResponse.CustomBody> handleException401(Exception401 e) {
+    return ApiResponseGenerator.fail(EXCEPTION_401_CODE, e.getMessage(), e.status());
+  }
+
+  @ExceptionHandler(Exception403.class)
+  public ApiResponse<ApiResponse.CustomBody> handleException403(Exception403 e) {
+    return ApiResponseGenerator.fail(EXCEPTION_403_CODE, e.getMessage(), e.status());
+  }
+
+  @ExceptionHandler(Exception404.class)
+  public ApiResponse<ApiResponse.CustomBody> handleException404(Exception404 e) {
+    return ApiResponseGenerator.fail(EXCEPTION_404_CODE, e.getMessage(), e.status());
+  }
+
+  @ExceptionHandler(Exception500.class)
+  public ApiResponse<ApiResponse.CustomBody> handleException500(Exception500 e) {
+    return ApiResponseGenerator.fail(EXCEPTION_500_CODE, e.getMessage(), e.status());
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
@@ -3,16 +3,16 @@ package com.kakaotech.team14backend.outer.post.controller;
 import com.kakaotech.team14backend.common.ApiResponse;
 import com.kakaotech.team14backend.common.ApiResponse.CustomBody;
 import com.kakaotech.team14backend.common.ApiResponseGenerator;
-import com.kakaotech.team14backend.outer.post.dto.GetPopularPostDTO;
+import com.kakaotech.team14backend.exception.Exception400;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListRequestDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostResponseDTO;
-import com.kakaotech.team14backend.outer.post.dto.UploadPostDTO;
-import com.kakaotech.team14backend.outer.post.dto.UploadPostRequestDTO;
 import com.kakaotech.team14backend.outer.post.dto.SetPostLikeDTO;
 import com.kakaotech.team14backend.outer.post.dto.SetPostLikeResponseDTO;
+import com.kakaotech.team14backend.outer.post.dto.UploadPostDTO;
+import com.kakaotech.team14backend.outer.post.dto.UploadPostRequestDTO;
 import com.kakaotech.team14backend.outer.post.service.PostService;
 import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
@@ -40,8 +40,12 @@ public class PostController {
       @RequestParam(value = "lastPostId", required = false) Long lastPostId,
       @RequestParam(defaultValue = "10") int size) {
 
-    // todo: size와 lastPostId 예외처리, validation
-
+    if (size <= 0) {
+      throw new Exception400("Size parameter must be greater than 0");
+    }
+    if (lastPostId != null && lastPostId < 0) {
+      throw new Exception400("lastPostId parameter must be greater than 0");
+    }
     GetPostListResponseDTO getPostListResponseDTO = postService.getPostList(lastPostId, size);
     return ApiResponseGenerator.success(getPostListResponseDTO, HttpStatus.OK);
   }
@@ -58,40 +62,44 @@ public class PostController {
   }
 
 
-
   @GetMapping("/post/{postId}")
-  public ApiResponse<ApiResponse.CustomBody<GetPostResponseDTO>> getPost(@PathVariable("postId") Long postId){
+  public ApiResponse<ApiResponse.CustomBody<GetPostResponseDTO>> getPost(
+      @PathVariable("postId") Long postId) {
     Long memberId = 1L;
     GetPostDTO getPostDTO = new GetPostDTO(postId, memberId);
     GetPostResponseDTO getPostResponseDTO = postService.getPost(getPostDTO);
-    return ApiResponseGenerator.success(getPostResponseDTO,HttpStatus.OK);
+    return ApiResponseGenerator.success(getPostResponseDTO, HttpStatus.OK);
   }
 
   @ApiOperation(value = "인기 피드 게시물 상세 조회")
   @GetMapping("/popular-post/{postId}")
-  public ApiResponse<ApiResponse.CustomBody<GetPostResponseDTO>> getPopularPost(@PathVariable("postId") Long postId){
+  public ApiResponse<ApiResponse.CustomBody<GetPostResponseDTO>> getPopularPost(
+      @PathVariable("postId") Long postId) {
     Long memberId = 1L;
     GetPostDTO getPostDTO = new GetPostDTO(postId, memberId);
     GetPostResponseDTO getPostResponseDTO = postService.getPopularPost(getPostDTO);
-    return ApiResponseGenerator.success(getPostResponseDTO,HttpStatus.OK);
+    return ApiResponseGenerator.success(getPostResponseDTO, HttpStatus.OK);
   }
 
   @ApiOperation(value = "인기 피드 게시물 조회", notes = "레벨당 게시물이 몇개가 필요한 지를 받아, 해당 레벨별 게시물들을 반환한다.")
   @GetMapping("/popular-post")
-  public ApiResponse<ApiResponse.CustomBody<GetPopularPostListResponseDTO>> getPopularPostList(GetPopularPostListRequestDTO getPopularPostListRequestDTO){
-    GetPopularPostListResponseDTO popularPostList = postService.getPopularPostList(getPopularPostListRequestDTO);
-    return ApiResponseGenerator.success(popularPostList,HttpStatus.OK);
+  public ApiResponse<ApiResponse.CustomBody<GetPopularPostListResponseDTO>> getPopularPostList(
+      GetPopularPostListRequestDTO getPopularPostListRequestDTO) {
+    GetPopularPostListResponseDTO popularPostList = postService.getPopularPostList(
+        getPopularPostListRequestDTO);
+    return ApiResponseGenerator.success(popularPostList, HttpStatus.OK);
   }
 
   @ApiOperation(value = "게시물 좋아요(추천 수)", notes = "게시물 좋아요를 누른다, 1인당 1개의 게시물에 1번만 좋아요를 누를 수 있다")
   @PostMapping("/post/{postId}/like")
-  public ApiResponse<ApiResponse.CustomBody<SetPostLikeResponseDTO>> setPostLike(@PathVariable("postId") Long postId){
+  public ApiResponse<ApiResponse.CustomBody<SetPostLikeResponseDTO>> setPostLike(
+      @PathVariable("postId") Long postId) {
     Long memberId = 1L;
 
     SetPostLikeDTO setPostLikeDTO = new SetPostLikeDTO(postId, memberId);
     SetPostLikeResponseDTO setPostLikeResponseDTO = postService.setPostLike(setPostLikeDTO);
 
-    return ApiResponseGenerator.success(setPostLikeResponseDTO,HttpStatus.OK);
+    return ApiResponseGenerator.success(setPostLikeResponseDTO, HttpStatus.OK);
   }
 
 }

--- a/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
+++ b/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
@@ -64,19 +64,19 @@ public class PostControllerTest {
   @Test
   void findAllHomeFeedWrongParam_Test() throws Exception {
 
-//    ResultActions resultActions = mockMvc.perform(
-//        get("/api/post")
-//            .param("lastPostId", "0")
-//            .param("size", "-1")
-//            .contentType(MediaType.APPLICATION_JSON));
-//
-//    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//
-//    System.out.println("findAllHomeFeedWrongParam_Test : " + responseBody);
-//
-//    resultActions.andExpect(status().isBadRequest());
-//    resultActions.andExpect(jsonPath("$.success").value(false));
-//    resultActions.andExpect(jsonPath("$.response").doesNotExist());
+    ResultActions resultActions = mockMvc.perform(
+        get("/api/post")
+            .param("lastPostId", "0")
+            .param("size", "-1")
+            .contentType(MediaType.APPLICATION_JSON));
+
+    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+
+    System.out.println("findAllHomeFeedWrongParam_Test : " + responseBody);
+
+    resultActions.andExpect(status().isBadRequest());
+    resultActions.andExpect(jsonPath("$.success").value(false));
+    resultActions.andExpect(jsonPath("$.response").doesNotExist());
   }
 
   @DisplayName("홈 피드를 조회한다 - 마지막 게시물 아이디가 없을 때")


### PR DESCRIPTION
- 전역 예외 핸들러 GlobalExceptionHandler 클래스를 구현하여 프로젝트 전반에 걸쳐 일관된 예외 처리를 제공합니다.
- 각 HTTP 상태 코드(400, 401, 403, 404, 500)에 대한 예외 클래스를 정의하고, GlobalExceptionHandler에서 이를 처리합니다.
- 게시물 조회 API의 getPosts 메소드에서 size와 lastPostId 파라미터의 유효성을 검사하고, 유효하지 않은 값이 전달될 경우 Exception400 예외를 발생시킵니다.
- 해당 예외는 GlobalExceptionHandler에서 처리되어 클라이언트에게 적절한 에러 응답을 반환합니다.

## 세부 예외처리 관련
- 기본적인 예외를 만들고, 세부 사항들은 점차 추가 할 예정입니다
- [Sonny](@hwangdaesun)님 코드보니 Message Code에서 예외 코드를 Enum으로 정하고 있어 Sonny 랑 예외 관련 이야기하면 좋을거 같아요! 

이슈 번호 :  #61
