### PR TITLE
인기 피드 리팩토링 및 테스트 보충

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/common/RedisKey.java
+++ b/src/main/java/com/kakaotech/team14backend/common/RedisKey.java
@@ -2,7 +2,8 @@ package com.kakaotech.team14backend.common;
 
 public enum RedisKey {
 
-  POPULAR_POST("popularPost"),
+  POPULAR_POST_PREFIX("popularPost:"),
+  VIEW_COUNT_PREFIX("postViewCount:")
 
   ;
 

--- a/src/main/java/com/kakaotech/team14backend/common/ScanRedisKey.java
+++ b/src/main/java/com/kakaotech/team14backend/common/ScanRedisKey.java
@@ -1,0 +1,37 @@
+package com.kakaotech.team14backend.common;
+
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ScanRedisKey {
+  public static List<String> scanKeysWithPattern(String pattern, RedisTemplate<String, Object> redisTemplate) {
+
+    List<String> keys = new ArrayList<>();
+
+    ScanOptions options = ScanOptions.scanOptions()
+        .match(pattern)
+        .count(1000) // 한 번에 가져올 키의 최대 수 (옵션)
+        .build();
+
+    Cursor<byte[]> cursor = redisTemplate.executeWithStickyConnection(
+        redisConnection -> redisConnection.scan(options)
+    );
+
+    while (cursor.hasNext()) {
+      String key = new String(cursor.next());
+      keys.add(key);
+    }
+
+    // 항상 cursor를 닫아주어야 합니다.
+    cursor.close();
+    return keys;
+  }
+
+
+}

--- a/src/main/java/com/kakaotech/team14backend/config/SecurityConfig.java
+++ b/src/main/java/com/kakaotech/team14backend/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
         .antMatchers("/api/user/**", "/api/board/*/like", "/api/kakao").authenticated()
         .antMatchers("/api/user/instagram").access("hasRole('ROLE_BEGINNER')") //인스타그램 연동X "ROLE_BEGINNER"
         .antMatchers("/api/board/point").access("hasRole('ROLE_USER')") //인스타그램 연동시 "ROLE_USER"
-        .antMatchers("/", "/api/login","/api/reissue", "/h2-console/*", "api/board", "api/popluar-board").permitAll()
+        .antMatchers("/", "/api/login","/api/reissue", "/h2-console/*", "api/post", "api/popluar-post").permitAll()
         .and()
         .oauth2Login()
         .successHandler(authenticationSuccessHandler)

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecase.java
@@ -39,7 +39,7 @@ public class FindPopularPostListUsecase {
 
       for(int j = 0; j < levelIndexes.get(i).size(); j++){
 
-        Set<LinkedHashMap<String, Object>> posts = redisTemplate.opsForZSet().range(RedisKey.POPULAR_POST.getKey(), j, j);
+        Set<LinkedHashMap<String, Object>> posts = redisTemplate.opsForZSet().range(RedisKey.POPULAR_POST_PREFIX.getKey(), j, j);
 
         List<GetIncompletePopularPostDTO> dtos = posts.stream().map(postMap -> {
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecase.java
@@ -39,7 +39,7 @@ public class FindPopularPostListUsecase {
 
       for(int j = 0; j < levelIndexes.get(i).size(); j++){
 
-        Set<LinkedHashMap<String, Object>> posts = redisTemplate.opsForZSet().range(RedisKey.POPULAR_POST_PREFIX.getKey(), j, j);
+        Set<LinkedHashMap<String, Object>> posts = redisTemplate.opsForZSet().range(RedisKey.POPULAR_POST_PREFIX.getKey(), levelIndexes.get(i).get(j) + 1, levelIndexes.get(i).get(j) + 1);
 
         List<GetIncompletePopularPostDTO> dtos = posts.stream().map(postMap -> {
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPopularPostListUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPopularPostListUsecase.java
@@ -27,7 +27,7 @@ public class SaveTemporaryPopularPostListUsecase {
   public void execute(){
     List<GetIncompletePopularPostDTO> top300Posts = postRepository.findTop300ByOrderByPopularityDesc(PageRequest.of(0, POPULARITY_SIZE));
     top300Posts.stream().forEach(getIncompletePopularPostDTO -> {
-      redisTemplate.opsForZSet().add(RedisKey.POPULAR_POST.getKey(), getIncompletePopularPostDTO, getIncompletePopularPostDTO.getPopularity().doubleValue());
+      redisTemplate.opsForZSet().add(RedisKey.POPULAR_POST_PREFIX.getKey(), getIncompletePopularPostDTO, getIncompletePopularPostDTO.getPopularity().doubleValue());
     });
 
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPostViewCountUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPostViewCountUsecase.java
@@ -1,8 +1,8 @@
 package com.kakaotech.team14backend.inner.post.usecase;
 
+import com.kakaotech.team14backend.common.RedisKey;
 import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CachePut;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,21 +15,17 @@ public class SaveTemporaryPostViewCountUsecase {
   private final RedisTemplate<String,Object> redisTemplate;
 
   /**
+   * 게시물에대한 조회수를 Redis에 임시 저장한다.
    *
-   * Set 자료구조에 key는 postId, value는 memberId를 저장
-   * 캐시에 key는 postId value에 해당 postId의 조회수 저장
+   * @author : hwangdaesun
+   * @param : 게시물 구분자, 유저 구분자
+   * @see : Redis의 Set 자료구조를 사용, key는 게시물 구분자, value는 유자 구분자
    */
 
   @Transactional
-  @CachePut(value = "viewCnt", key = "#getPostDTO.postId().toString()")
-  public Long execute(GetPostDTO getPostDTO) {
+  public void execute(GetPostDTO getPostDTO) {
     // 데이터를 Redis Set에 추가하는 코드
-    redisTemplate.opsForSet().add(String.valueOf(getPostDTO.postId()), getPostDTO.memberId());
-
-    // Redis Set 자료구조에서 해당 key 즉 postId에 있는 value들의 갯수 반환
-    long setSize = redisTemplate.opsForSet().size(String.valueOf(getPostDTO.postId()));
-
-    return setSize;
+    redisTemplate.opsForSet().add(RedisKey.VIEW_COUNT_PREFIX + String.valueOf(getPostDTO.postId()), getPostDTO.memberId());
   }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
@@ -16,9 +16,13 @@ import com.kakaotech.team14backend.outer.post.dto.UploadPostRequestDTO;
 import com.kakaotech.team14backend.outer.post.service.PostService;
 import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -84,7 +88,19 @@ public class PostController {
   @ApiOperation(value = "인기 피드 게시물 조회", notes = "레벨당 게시물이 몇개가 필요한 지를 받아, 해당 레벨별 게시물들을 반환한다.")
   @GetMapping("/popular-post")
   public ApiResponse<ApiResponse.CustomBody<GetPopularPostListResponseDTO>> getPopularPostList(
-      GetPopularPostListRequestDTO getPopularPostListRequestDTO) {
+      @RequestParam Integer level1 , @RequestParam Integer level2, @RequestParam Integer level3) {
+
+    if(level1 >= 20 | level2 >= 20 | level3 >= 20){
+      throw  new Exception400("Level size must be smaller than 20");
+    }
+
+    Map<Integer,Integer> levelSize = new HashMap<>();
+    levelSize.put(1,level1);
+    levelSize.put(2,level2);
+    levelSize.put(3,level3);
+
+    GetPopularPostListRequestDTO getPopularPostListRequestDTO = new GetPopularPostListRequestDTO(levelSize);
+
     GetPopularPostListResponseDTO popularPostList = postService.getPopularPostList(
         getPopularPostListRequestDTO);
     return ApiResponseGenerator.success(popularPostList, HttpStatus.OK);

--- a/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
@@ -1,6 +1,5 @@
 package com.kakaotech.team14backend.outer.post.mapper;
 
-import com.kakaotech.team14backend.inner.image.model.Image;
 import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.outer.post.dto.GetIncompletePopularPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostDTO;

--- a/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
@@ -65,6 +65,15 @@ public class PostService {
     return findPostListUsecase.excute(lastPostId, size);
   }
 
+  /**
+   * 인기 게시물을 상세조회한다.
+   *
+   * @author : hwangdaesun
+   * @param : 게시물 구분자, 유저 구분자
+   * @return : 인기 게시물 상세 조회시 반환 값
+   * @see : saveTemporaryPostViewCountUsecase는 게시물 조회시 게시물의 조회수를 늘려주는 클래스
+   */
+
   public GetPostResponseDTO getPopularPost(GetPostDTO getPostDTO) {
     saveTemporaryPostViewCountUsecase.execute(getPostDTO);
     GetPostResponseDTO getPostResponseDTO =findPopularPostUsecase.execute(getPostDTO);

--- a/src/main/resources/db/teardown.sql
+++ b/src/main/resources/db/teardown.sql
@@ -24,6 +24,7 @@ VALUES (NOW(), 'image_uri1'),
        (NOW(), 'image_uri8'),
        (NOW(), 'image_uri9'),
        (NOW(), 'image_uri10');
+
 -- Post Table
 INSERT INTO post (created_at, nickname, popularity, published, report_count, university, view_count,
                   post_point,
@@ -49,8 +50,33 @@ VALUES (NOW(), 'nickname1', 100, true, 0, 'university1', 1000, 400, 1, 1, '#hash
        (NOW(), 'nickname19', 900, false, 8, 'university9', 9000, 400, 9, 3, '#hashtag9'),
        (NOW(), 'nickname20', 1000, true, 9, 'university10', 10000, 400, 10, 1, '#hashtag10');
 
--- PostLikeCount Table
+-- Using UNION ALL to generate numbers up to 280
+WITH RECURSIVE numbers(val) AS (
+    SELECT 1
+    UNION ALL
+    SELECT val + 1
+    FROM numbers
+    WHERE val < 280
+)
+
+INSERT INTO post (created_at, nickname, popularity, published, report_count, university, view_count, post_point, image_id, member_id, hashtag)
+SELECT
+    NOW(),
+    'nickname' || (val + 20),
+    (val * 100),
+    CASE WHEN val % 2 = 0 THEN true ELSE false END,
+    0,
+    'university' || ((val % 10) + 1),
+    (val * 1000),
+    400,
+    ((val % 10) + 1),
+    ((val % 3) + 1),
+    '#hashtag' || ((val % 10) + 1)
+FROM numbers;
+
+
+-- Insert PostLikeCount for all the 300 posts
 INSERT INTO post_like_count (post_id, like_count, created_at, modified_at)
 SELECT post_id, 0, NOW(), NOW()
 FROM post
-WHERE post_id BETWEEN 1 AND 20;
+WHERE post_id BETWEEN 1 AND 300;

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecaseTest.java
@@ -1,19 +1,11 @@
 package com.kakaotech.team14backend.inner.post.usecase;
 
 import com.kakaotech.team14backend.common.RedisKey;
-import com.kakaotech.team14backend.inner.image.model.Image;
-import com.kakaotech.team14backend.inner.image.repository.ImageRepository;
-import com.kakaotech.team14backend.inner.member.model.Member;
-import com.kakaotech.team14backend.inner.member.model.Role;
-import com.kakaotech.team14backend.inner.member.model.Status;
-import com.kakaotech.team14backend.inner.member.repository.MemberRepository;
 import com.kakaotech.team14backend.inner.post.model.Post;
-import com.kakaotech.team14backend.inner.post.model.PostLikeCount;
 import com.kakaotech.team14backend.inner.post.model.PostRandomFetcher;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import com.kakaotech.team14backend.outer.post.dto.GetIncompletePopularPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListResponseDTO;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,8 +16,6 @@ import org.springframework.test.context.jdbc.Sql;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Sql("classpath:db/teardown.sql")
@@ -49,10 +39,10 @@ class FindPopularPostListUsecaseTest {
    */
   @BeforeEach
   void setUp() {
-    redisTemplate.delete(RedisKey.POPULAR_POST.getKey());
+    redisTemplate.delete(RedisKey.POPULAR_POST_PREFIX.getKey());
     List<Post> posts = postRepository.findAll();
     posts.forEach(post -> {
-      redisTemplate.opsForZSet().add(RedisKey.POPULAR_POST.getKey(),new GetIncompletePopularPostDTO(post.getPostId(),post.getImage().getImageUri(),post.getHashtag(),post.getPostLikeCount().getLikeCount(),post.getPostPoint(),post.getPopularity(),post.getNickname()),post.getPopularity());
+      redisTemplate.opsForZSet().add(RedisKey.POPULAR_POST_PREFIX.getKey(),new GetIncompletePopularPostDTO(post.getPostId(),post.getImage().getImageUri(),post.getHashtag(),post.getPostLikeCount().getLikeCount(),post.getPostPoint(),post.getPopularity(),post.getNickname()),post.getPopularity());
     });
   }
 

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPopularPostListUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPopularPostListUsecaseTest.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team14backend.inner.post.usecase;
 
+import com.kakaotech.team14backend.common.RedisKey;
 import com.kakaotech.team14backend.inner.image.model.Image;
 import com.kakaotech.team14backend.inner.image.repository.ImageRepository;
 import com.kakaotech.team14backend.inner.member.model.Member;
@@ -18,6 +19,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -39,11 +41,12 @@ class SaveTemporaryPopularPostListUsecaseTest {
   @Autowired
   private RedisTemplate redisTemplate;
 
-  private final String key = "popularPost";
-
   @BeforeEach
   void setUp() {
-    redisTemplate.delete(key);
+    Set keys = redisTemplate.keys(RedisKey.POPULAR_POST_PREFIX + "*");
+    for(Object key : keys){
+      redisTemplate.delete(key);
+    }
     postRepository.deleteAll();
     Member member = Member.createMember("Sonny", "1234", "asdfc", Role.ROLE_USER, 12L,
         Status.STATUS_ACTIVE);
@@ -62,7 +65,8 @@ class SaveTemporaryPopularPostListUsecaseTest {
     List<Post> posts = postRepository.findAll();
     System.out.println(posts.size());
     saveTemporaryPopularPostListUsecase.execute();
-    Long size = redisTemplate.opsForZSet().size(key);
+    Set keys = redisTemplate.keys(RedisKey.POPULAR_POST_PREFIX + "*");
+    int size = keys.size();
     org.assertj.core.api.Assertions.assertThat(size).isEqualTo(1);
   }
 }

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPostViewCountUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPostViewCountUsecaseTest.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team14backend.inner.post.usecase;
 
+import com.kakaotech.team14backend.common.RedisKey;
 import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -22,45 +25,32 @@ class SaveTemporaryPostViewCountUsecaseTest {
   @Autowired
   private SaveTemporaryPostViewCountUsecase saveTemporaryPostViewCountUsecase;
 
-  @Autowired
-  private CacheManager cacheManager;
-
   @BeforeEach
   @DisplayName("게시글 1을 회원 2와 회원 3이 방문한 경우")
   void setUp() {
-    redisTemplate.delete("1");
-    redisTemplate.opsForSet().add("1",2L);
-    redisTemplate.opsForSet().add("1",3L);
+    redisTemplate.delete(RedisKey.VIEW_COUNT_PREFIX + "1");
+    redisTemplate.opsForSet().add(RedisKey.VIEW_COUNT_PREFIX + "1",2L);
+    redisTemplate.opsForSet().add(RedisKey.VIEW_COUNT_PREFIX + "1",3L);
   }
 
   @Test
-  @DisplayName("updatePostViewCountUsecase.execute(getPostDTO) 에서 Set 자료구조를 활용한 로직이 잘 동작하는 지 확인")
+  @DisplayName("게시물당 조회수 count 기능 검증")
   void execute_updateUsingSet1() {
-    Cache cache = cacheManager.getCache("viewCnt");
-    cache.clear();
-
     GetPostDTO getPostDTO = new GetPostDTO(1L,1L);
     saveTemporaryPostViewCountUsecase.execute(getPostDTO);
-    Long size = redisTemplate.opsForSet().size("1");
+    Long size = redisTemplate.opsForSet().size(RedisKey.VIEW_COUNT_PREFIX+ "1");
     Assertions.assertThat(size).isEqualTo(3);
   }
 
   @Test
-  @DisplayName("updatePostViewCountUsecase.execute(getPostDTO) 에서 Set 자료구조를 활용한 로직이 잘 동작하는 지 확인")
+  @DisplayName("게시물당 조회수 count 기능 검즘 - 10분동안 동일 게시물 동일 유저는 조회수는 증가되지 않는다.")
   void execute_updateUsingSet2() {
-    GetPostDTO getPostDTO = new GetPostDTO(2L,1L);
+    GetPostDTO getPostDTO = new GetPostDTO(1L,2L);
     saveTemporaryPostViewCountUsecase.execute(getPostDTO);
-    Long size = redisTemplate.opsForSet().size("1");
+    Long size = redisTemplate.opsForSet().size(RedisKey.VIEW_COUNT_PREFIX + "1");
     Assertions.assertThat(size).isEqualTo(2);
   }
 
-  @Test
-  @DisplayName("캐시가 잘 저장되어 있는 지 확인")
-  void execute_saveCache() {
-    GetPostDTO getPostDTO = new GetPostDTO(1L,1L);
-    Long result = saveTemporaryPostViewCountUsecase.execute(getPostDTO);
-    assertEquals(result,3);
-  }
 
 
 }

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostViewCountTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostViewCountTest.java
@@ -1,7 +1,6 @@
 package com.kakaotech.team14backend.inner.post.usecase;
 
-import static org.awaitility.Awaitility.await;
-
+import com.kakaotech.team14backend.common.RedisKey;
 import com.kakaotech.team14backend.inner.image.model.Image;
 import com.kakaotech.team14backend.inner.image.repository.ImageRepository;
 import com.kakaotech.team14backend.inner.member.model.Member;
@@ -10,13 +9,9 @@ import com.kakaotech.team14backend.inner.member.model.Status;
 import com.kakaotech.team14backend.inner.member.repository.MemberRepository;
 import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.model.PostLikeCount;
-import com.kakaotech.team14backend.inner.post.repository.PostLikeCountRepository;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
-import java.time.Duration;
-import java.util.concurrent.Callable;
-
-import com.kakaotech.team14backend.outer.post.schedule.SchedulePostViewCount;
+import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,17 +20,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 
-@SpringBootTest(properties = {
-    "schedules.initialDelay:1000"
-    ,"schedules.fixedDelay:1000"
-})
-class SchedulePostViewCountTest {
+@SpringBootTest
+class UpdatePostViewCountTest {
 
   @Autowired
   private SaveTemporaryPostViewCountUsecase saveTemporaryPostViewCountUsecase;
 
   @Autowired
-  private SchedulePostViewCount schedulePostViewCount;
+  private UpdatePostViewCountUsecase updatePostViewCountUsecase;
 
   @Autowired
   private PostRepository postRepository;
@@ -47,16 +39,16 @@ class SchedulePostViewCountTest {
   private ImageRepository imageRepository;
 
   @Autowired
-  private PostLikeCountRepository postLikeRepository;
-
-  @Autowired
   private RedisTemplate redisTemplate;
 
 
   @BeforeEach
   void setup(){
 
-    redisTemplate.delete("viewCnt");
+    Set keys = redisTemplate.keys(RedisKey.VIEW_COUNT_PREFIX + "*");
+    for (Object key : keys){
+      redisTemplate.delete(key);
+    }
 
     Member member = new Member("sonny", "sonny1234","asdf324", Role.ROLE_BEGINNER,0L, Status.STATUS_ACTIVE);
     memberRepository.save(member);
@@ -71,29 +63,21 @@ class SchedulePostViewCountTest {
 
   }
 
-  @DisplayName("1번 게시물을 각각 1번과 2번 유저가 조회한 상황에서 레디스에 저장되어있는 게시글 당 조회수를 스케줄링을 사용하여 MySQL에 업데이트")
+  @DisplayName("게시물의 조회수 update 테스트")
   @Test
   void execute() {
 
-    Callable<Boolean> viewCount = (Callable<Boolean>) () -> {
+    GetPostDTO getPostDTO = new GetPostDTO(1L, 1L);
+    saveTemporaryPostViewCountUsecase.execute(getPostDTO);
 
-      GetPostDTO getPostDTO = new GetPostDTO(1L,1L);
-      saveTemporaryPostViewCountUsecase.execute(getPostDTO);
+    GetPostDTO getPostDTO1 = new GetPostDTO(1L, 2L);
+    saveTemporaryPostViewCountUsecase.execute(getPostDTO1);
 
-      GetPostDTO getPostDTO1 = new GetPostDTO(1L,2L);
-      saveTemporaryPostViewCountUsecase.execute(getPostDTO1);
+    updatePostViewCountUsecase.execute();
 
-      schedulePostViewCount.execute();
+    Post post = postRepository.findById(1L).get();
 
-      Post post = postRepository.findById(1L).get();
-
-      Assertions.assertThat(post.getViewCount()).isEqualTo(3);
-      return true;
-    };
-
-    await()
-        .atMost(Duration.ofMinutes(1L))
-        .until(viewCount);
+    Assertions.assertThat(post.getViewCount()).isEqualTo(2);
   }
 
 }

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostViewCountTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostViewCountTest.java
@@ -11,7 +11,7 @@ import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.model.PostLikeCount;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
-import java.util.Set;
+import com.kakaotech.team14backend.outer.post.schedule.SchedulePostViewCount;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Set;
 
 @SpringBootTest
 class UpdatePostViewCountTest {
@@ -28,6 +30,7 @@ class UpdatePostViewCountTest {
 
   @Autowired
   private UpdatePostViewCountUsecase updatePostViewCountUsecase;
+
 
   @Autowired
   private PostRepository postRepository;
@@ -40,6 +43,9 @@ class UpdatePostViewCountTest {
 
   @Autowired
   private RedisTemplate redisTemplate;
+
+  @Autowired
+  private SchedulePostViewCount schedulePostViewCount;
 
 
   @BeforeEach
@@ -76,6 +82,7 @@ class UpdatePostViewCountTest {
     updatePostViewCountUsecase.execute();
 
     Post post = postRepository.findById(1L).get();
+    schedulePostViewCount.execute();
 
     Assertions.assertThat(post.getViewCount()).isEqualTo(2);
   }

--- a/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
+++ b/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
@@ -5,6 +5,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Sql("classpath:db/teardown.sql")
@@ -30,6 +33,8 @@ public class PostControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
+  @Autowired
+  private PostRepository postRepository;
 
   @DisplayName("홈 피드를 조회한다 - 정상 파라미터")
   @Test
@@ -119,7 +124,7 @@ public class PostControllerTest {
     resultActions.andExpect(jsonPath("$.response").exists());
   }
 
-  @DisplayName("인기 피드를 조회 - 정상 파라미터")
+  @DisplayName("인기 피드를 조회 - 비정상 파라미터")
   @Test
   void findAllPopularPostExeedLevelSize_Test() throws Exception {
 

--- a/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
+++ b/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
@@ -16,6 +16,9 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Sql("classpath:db/teardown.sql")
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = WebEnvironment.MOCK)
@@ -94,6 +97,46 @@ public class PostControllerTest {
     resultActions.andExpect(status().isOk());
     resultActions.andExpect(jsonPath("$.success").value(true));
     resultActions.andExpect(jsonPath("$.response").exists());
+  }
+
+  @DisplayName("인기 피드를 조회 - 정상 파라미터")
+  @Test
+  void findAllPopularPost_Test() throws Exception {
+
+    ResultActions resultActions = mockMvc.perform(
+        get("/api/popular-post")
+            .param("level3", "4")
+            .param("level2", "3")
+            .param("level1", "3")
+            .contentType(MediaType.APPLICATION_JSON));
+
+    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+
+    System.out.println("findAllPopularPost_Test : " + responseBody);
+
+    resultActions.andExpect(status().isOk());
+    resultActions.andExpect(jsonPath("$.success").value(true));
+    resultActions.andExpect(jsonPath("$.response").exists());
+  }
+
+  @DisplayName("인기 피드를 조회 - 정상 파라미터")
+  @Test
+  void findAllPopularPostExeedLevelSize_Test() throws Exception {
+
+    ResultActions resultActions = mockMvc.perform(
+        get("/api/popular-post")
+            .param("level3", "20")
+            .param("level2", "3")
+            .param("level1", "3")
+            .contentType(MediaType.APPLICATION_JSON));
+
+    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+
+    System.out.println("findAllPopularPost_Test : " + responseBody);
+
+    resultActions.andExpect(status().isBadRequest());
+    resultActions.andExpect(jsonPath("$.success").value(false));
+    resultActions.andExpect(jsonPath("$.response").doesNotExist());
   }
 
 }


### PR DESCRIPTION
인기 피드 상세 조회 및 전체조회 관련 코드들을 리팩토링하였습니다.

## Commit 요약


### refactor : RedisKey 클래스 생성하여 Redis 관련 key들 한번에 관리 및 명명 규칙 통일

### refactor : 캐시 제거

todo : 기능 개발이 완성된 후 캐시 도입

### test : PostContoroller의 인기 피드 전체 조회 테스트 추가

### feat : PostController의 인기 피드 전체 조회 예외 처리 

### feat : teardown.sql의 post 테이블에 300개 데이터 삽입
