### PR TITLE
My Page 유저가 올린 게시물들 조회하는 기능 구현 with PairProgramming

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/post/repository/PostRepository.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/repository/PostRepository.java
@@ -1,9 +1,8 @@
 package com.kakaotech.team14backend.inner.post.repository;
 
 import com.kakaotech.team14backend.inner.post.model.Post;
-import java.util.List;
-
 import com.kakaotech.team14backend.outer.post.dto.GetIncompletePopularPostDTO;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -20,4 +19,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
       "ORDER BY p.popularity DESC")
   List<GetIncompletePopularPostDTO> findTop300ByOrderByPopularityDesc(Pageable pageable);
 
+  @Query("SELECT p FROM Post p WHERE p.member.memberId = :memberId")
+  List<Post> findByMemberId(Long memberId, Pageable pageable);
+
+  @Query("SELECT p FROM Post p WHERE p.member.memberId = :memberId AND p.postId > :lastPostId")
+  List<Post> findByMemberIdAndPostIdGreaterThan(Long memberId, Long lastPostId, Pageable pageable);
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPersonalPostListUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPersonalPostListUsecase.java
@@ -1,0 +1,39 @@
+package com.kakaotech.team14backend.inner.post.usecase;
+
+import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.inner.post.repository.PostRepository;
+import com.kakaotech.team14backend.outer.post.dto.GetPersonalPostListResponseDTO;
+import com.kakaotech.team14backend.outer.post.mapper.PostMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FindPersonalPostListUsecase {
+
+  private final PostRepository postRepository;
+
+  public GetPersonalPostListResponseDTO excute(Long memberId, Long lastPostId, int size) {
+
+    Pageable pageable = PageRequest.of(0, size + 1, Sort.by(Direction.DESC, "postId"));
+
+    List<Post> postList;
+    if (lastPostId == null) {
+      postList = postRepository.findByMemberId(memberId, pageable);
+    } else {
+      postList = postRepository.findByMemberIdAndPostIdGreaterThan(memberId, lastPostId, pageable);
+    }
+
+    boolean hasNext = false;
+    if (postList.size() > size) {
+      hasNext = true;
+      postList.subList(0, size);
+    }
+    return new GetPersonalPostListResponseDTO(PostMapper.fromPersonalPostList(postList), hasNext);
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
@@ -4,6 +4,7 @@ import com.kakaotech.team14backend.common.ApiResponse;
 import com.kakaotech.team14backend.common.ApiResponse.CustomBody;
 import com.kakaotech.team14backend.common.ApiResponseGenerator;
 import com.kakaotech.team14backend.exception.Exception400;
+import com.kakaotech.team14backend.outer.post.dto.GetPersonalPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListRequestDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
@@ -18,11 +19,9 @@ import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,6 +36,17 @@ import org.springframework.web.multipart.MultipartFile;
 public class PostController {
 
   private final PostService postService;
+
+  @GetMapping("/post/user")// 유저가 올린 게시물 조회
+  public ApiResponse<CustomBody<GetPersonalPostListResponseDTO>> getPersonalPostList(
+      @RequestParam("userId") Long userId,
+      @RequestParam(value = "lastPostId", required = false) Long lastPostId,
+      @RequestParam(defaultValue = "10") int size) {
+
+    GetPersonalPostListResponseDTO getPostListResponseDTO = postService.getPersonalPostList(userId,
+        lastPostId, size);
+    return ApiResponseGenerator.success(getPostListResponseDTO, HttpStatus.OK);
+  }
 
   @ApiOperation(value = "홈 피드의 게시물 조회", notes = "마지막 게시물의 id를 받아서 그 이후의 게시물을 조회한다. lastPostId가 없다면 첫 게시물을 조회한다")
   @GetMapping("/post")
@@ -65,7 +75,6 @@ public class PostController {
     return ApiResponseGenerator.success(HttpStatus.CREATED);
   }
 
-
   @GetMapping("/post/{postId}")
   public ApiResponse<ApiResponse.CustomBody<GetPostResponseDTO>> getPost(
       @PathVariable("postId") Long postId) {
@@ -88,18 +97,19 @@ public class PostController {
   @ApiOperation(value = "인기 피드 게시물 조회", notes = "레벨당 게시물이 몇개가 필요한 지를 받아, 해당 레벨별 게시물들을 반환한다.")
   @GetMapping("/popular-post")
   public ApiResponse<ApiResponse.CustomBody<GetPopularPostListResponseDTO>> getPopularPostList(
-      @RequestParam Integer level1 , @RequestParam Integer level2, @RequestParam Integer level3) {
+      @RequestParam Integer level1, @RequestParam Integer level2, @RequestParam Integer level3) {
 
-    if(level1 >= 20 | level2 >= 20 | level3 >= 20){
-      throw  new Exception400("Level size must be smaller than 20");
+    if (level1 >= 20 | level2 >= 20 | level3 >= 20) {
+      throw new Exception400("Level size must be smaller than 20");
     }
 
-    Map<Integer,Integer> levelSize = new HashMap<>();
-    levelSize.put(1,level1);
-    levelSize.put(2,level2);
-    levelSize.put(3,level3);
+    Map<Integer, Integer> levelSize = new HashMap<>();
+    levelSize.put(1, level1);
+    levelSize.put(2, level2);
+    levelSize.put(3, level3);
 
-    GetPopularPostListRequestDTO getPopularPostListRequestDTO = new GetPopularPostListRequestDTO(levelSize);
+    GetPopularPostListRequestDTO getPopularPostListRequestDTO = new GetPopularPostListRequestDTO(
+        levelSize);
 
     GetPopularPostListResponseDTO popularPostList = postService.getPopularPostList(
         getPopularPostListRequestDTO);

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPersonalPostListResponseDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPersonalPostListResponseDTO.java
@@ -1,0 +1,7 @@
+package com.kakaotech.team14backend.outer.post.dto;
+
+import java.util.List;
+
+public record GetPersonalPostListResponseDTO(List<GetPersonalPostResponseDTO> postList, Boolean hasNext) {
+
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPersonalPostResponseDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPersonalPostResponseDTO.java
@@ -1,0 +1,19 @@
+package com.kakaotech.team14backend.outer.post.dto;
+
+import java.time.Instant;
+
+public record GetPersonalPostResponseDTO(Long postid, String imageUri, String nickname,
+                                         Instant createdAt, Long viewCount, Long likeCount) {
+
+//  {
+//    "postid": "123456",
+//      "imageUri": "12345",
+//      "nickname": "가은",
+//      "createdAt": "",
+//      "viewCount": 10,
+//      "likeCount": 50
+//  },
+}
+
+// DTO 예시
+// public record GetPersonalPostListResponseDTO(List<GetPostResponseDTO> postList, Boolean hasNext) {}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
@@ -2,6 +2,7 @@ package com.kakaotech.team14backend.outer.post.mapper;
 
 import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.outer.post.dto.GetIncompletePopularPostDTO;
+import com.kakaotech.team14backend.outer.post.dto.GetPersonalPostResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostResponseDTO;
@@ -15,15 +16,30 @@ import java.util.stream.Collectors;
 
 public class PostMapper {
 
-  public static GetPostResponseDTO from(Post post){
-    return new GetPostResponseDTO(post.getPostId(),post.getImage().getImageUri(), splitHashtag(post.getHashtag()), 0L, 0, post.getNickname());
+  public static GetPostResponseDTO from(Post post) {
+    return new GetPostResponseDTO(post.getPostId(), post.getImage().getImageUri(),
+        splitHashtag(post.getHashtag()), 0L, 0, post.getNickname());
   }
+
   public static List<GetPostResponseDTO> from(List<Post> postList) {
     List<GetPostResponseDTO> editedPostList = postList.stream().map(PostMapper::from).toList();
     return editedPostList;
   }
 
-  public static GetPopularPostListResponseDTO from(Map<Integer, Set<GetIncompletePopularPostDTO>> levelPosts) {
+  public static List<GetPersonalPostResponseDTO> fromPersonalPostList(List<Post> postList) {
+    List<GetPersonalPostResponseDTO> editedPostList = new ArrayList<>();
+    for (Post post : postList) {
+      editedPostList.add(
+          new GetPersonalPostResponseDTO(post.getPostId(), post.getImage().getImageUri(),
+              post.getNickname(), post.getCreatedAt(), post.getViewCount(),
+              post.getPostLikeCount().getLikeCount()));
+    }
+    return editedPostList;
+  }
+
+
+  public static GetPopularPostListResponseDTO from(
+      Map<Integer, Set<GetIncompletePopularPostDTO>> levelPosts) {
     List<GetPopularPostDTO> popularPosts = new ArrayList<>();
 
     for (Map.Entry<Integer, Set<GetIncompletePopularPostDTO>> entry : levelPosts.entrySet()) {
@@ -34,15 +50,9 @@ public class PostMapper {
         List<String> hashTags = splitHashtag(incompletePost.getHashTag());
         int boardPoint = 0;
 
-        GetPopularPostDTO popularPost = new GetPopularPostDTO(
-            incompletePost.getPostId(),
-            incompletePost.getImageUri(),
-            hashTags,
-            incompletePost.getLikeCount(),
-            boardPoint,
-            incompletePost.getNickname(),
-            postLevel
-        );
+        GetPopularPostDTO popularPost = new GetPopularPostDTO(incompletePost.getPostId(),
+            incompletePost.getImageUri(), hashTags, incompletePost.getLikeCount(), boardPoint,
+            incompletePost.getNickname(), postLevel);
         popularPosts.add(popularPost);
       }
     }
@@ -50,7 +60,7 @@ public class PostMapper {
     return new GetPopularPostListResponseDTO(popularPosts);
   }
 
-  private static List<String> splitHashtag(String hashTag){
+  private static List<String> splitHashtag(String hashTag) {
     String cuttingHashTag = hashTag.substring(1);
     String[] splitHashtags = cuttingHashTag.split("#");
     return Arrays.stream(splitHashtags).collect(Collectors.toList());

--- a/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
@@ -5,15 +5,16 @@ import com.kakaotech.team14backend.inner.image.usecase.CreateImageUsecase;
 import com.kakaotech.team14backend.inner.member.model.Member;
 import com.kakaotech.team14backend.inner.member.usecase.FindMemberUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.CreatePostUsecase;
+import com.kakaotech.team14backend.inner.post.usecase.FindPersonalPostListUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.FindPopularPostListUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.FindPopularPostUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.FindPostListUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.FindPostUsecase;
-import com.kakaotech.team14backend.inner.post.usecase.UpdatePostLikeCountUsecase;
-import com.kakaotech.team14backend.inner.post.usecase.SetPostLikeUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.SaveTemporaryPostViewCountUsecase;
+import com.kakaotech.team14backend.inner.post.usecase.SetPostLikeUsecase;
+import com.kakaotech.team14backend.inner.post.usecase.UpdatePostLikeCountUsecase;
 import com.kakaotech.team14backend.outer.post.dto.CreatePostDTO;
-import com.kakaotech.team14backend.outer.post.dto.GetIncompletePopularPostDTO;
+import com.kakaotech.team14backend.outer.post.dto.GetPersonalPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListRequestDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
@@ -24,9 +25,6 @@ import com.kakaotech.team14backend.outer.post.dto.SetPostLikeDTO;
 import com.kakaotech.team14backend.outer.post.dto.SetPostLikeResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.UploadPostDTO;
 import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,12 +44,20 @@ public class PostService {
   private final SetPostLikeUsecase setPostLikeUsecase;
   private final FindPopularPostListUsecase findPopularPostListUsecase;
   private final UpdatePostLikeCountUsecase updatePostLikeCountUsecase;
+  private final FindPersonalPostListUsecase findPersonalPostListUsecase;
+
+  public GetPersonalPostListResponseDTO getPersonalPostList(Long userId, Long lastPostId, int size) {
+
+    return findPersonalPostListUsecase.excute(userId, lastPostId, size);
+  }
 
   @Transactional
   public void uploadPost(UploadPostDTO uploadPostDTO) throws IOException {
     Member savedMember = findMemberUsecase.execute(uploadPostDTO.memberId());
-    Image savedImage = createImageUsecase.execute(uploadPostDTO.image(), uploadPostDTO.uploadPostRequestDTO().getImageName());
-    CreatePostDTO createPostDTO = new CreatePostDTO(savedImage, uploadPostDTO.uploadPostRequestDTO(), savedMember);
+    Image savedImage = createImageUsecase.execute(uploadPostDTO.image(),
+        uploadPostDTO.uploadPostRequestDTO().getImageName());
+    CreatePostDTO createPostDTO = new CreatePostDTO(savedImage,
+        uploadPostDTO.uploadPostRequestDTO(), savedMember);
     createPostUsecase.execute(createPostDTO);
   }
 
@@ -68,15 +74,15 @@ public class PostService {
   /**
    * 인기 게시물을 상세조회한다.
    *
-   * @author : hwangdaesun
    * @param : 게시물 구분자, 유저 구분자
    * @return : 인기 게시물 상세 조회시 반환 값
+   * @author : hwangdaesun
    * @see : saveTemporaryPostViewCountUsecase는 게시물 조회시 게시물의 조회수를 늘려주는 클래스
    */
 
   public GetPostResponseDTO getPopularPost(GetPostDTO getPostDTO) {
     saveTemporaryPostViewCountUsecase.execute(getPostDTO);
-    GetPostResponseDTO getPostResponseDTO =findPopularPostUsecase.execute(getPostDTO);
+    GetPostResponseDTO getPostResponseDTO = findPopularPostUsecase.execute(getPostDTO);
     return getPostResponseDTO;
   }
 
@@ -91,8 +97,10 @@ public class PostService {
     return isLiked;
   }
 
-  public GetPopularPostListResponseDTO getPopularPostList(GetPopularPostListRequestDTO getPopularPostListRequestDTO){
-    GetPopularPostListResponseDTO getPopularPostListResponseDTO = findPopularPostListUsecase.execute(getPopularPostListRequestDTO.levelSize());
+  public GetPopularPostListResponseDTO getPopularPostList(
+      GetPopularPostListRequestDTO getPopularPostListRequestDTO) {
+    GetPopularPostListResponseDTO getPopularPostListResponseDTO = findPopularPostListUsecase.execute(
+        getPopularPostListRequestDTO.levelSize());
     return getPopularPostListResponseDTO;
   }
 

--- a/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
+++ b/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
@@ -5,7 +5,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,10 +16,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 @Sql("classpath:db/teardown.sql")
 @AutoConfigureMockMvc
@@ -35,6 +30,26 @@ public class PostControllerTest {
 
   @Autowired
   private PostRepository postRepository;
+
+  @DisplayName("단일 유저가 올린 게시물들을 조회합니다")
+  @Test
+  void getPersonalPostList_Test() throws Exception {
+
+    ResultActions resultActions = mockMvc.perform(
+        get("/api/post/user")
+            .param("userId", "1")
+            .param("lastPostId", "0")
+            .param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON));
+
+    String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+
+    System.out.println("getPostByUser_Test : " + responseBody);
+
+    resultActions.andExpect(status().isOk());
+    resultActions.andExpect(jsonPath("$.success").value(true));
+    resultActions.andExpect(jsonPath("$.response").exists());
+  }
 
   @DisplayName("홈 피드를 조회한다 - 정상 파라미터")
   @Test


### PR DESCRIPTION
"My Page" 기능에 유저가 올린 게시물을 조회하는 기능을 구현한 내용을 포함하고 있습니다. 
이 작업은 Pair Programming을 통해 수행되었으며, 다음과 같은 주요 변경사항을 포함하고 있습니다:

@GetMapping("/post/user") 엔드포인트를 추가하여 유저가 올린 게시물을 조회할 수 있도록 함

사용자 ID, 마지막 게시물 ID, 페이지 크기를 파라미터로 받아 조회 기능을 구현.
GetPersonalPostListResponseDTO를 사용하여 응답을 생성.

## 변경 내용

1. 게시물 조회 기능 추가
2. API 엔드포인트 추가
3. DTO 클래스 추가
4. 서비스 및 유즈케이스 로직 추가