### PR TITLE
인기 피드 전체 조회 기능 - 단위테스트는 성공하지만, "Run all Tests"로 모든 단위테스트를 한번에 돌릴 때는 실패하는 이슈 해결

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/point/usecase/CreatePointUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/point/usecase/CreatePointUsecase.java
@@ -22,7 +22,4 @@ public class CreatePointUsecase {
     pointRepository.save(userPoint);
   }
 
-  // create : 처음 유저가 포인트를 다룰 때, 회원가입 밖에 없긴함
-  // give, use
-  // 우려 사항 :
 }

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPopularPostListUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SaveTemporaryPopularPostListUsecaseTest.java
@@ -3,6 +3,9 @@ package com.kakaotech.team14backend.inner.post.usecase;
 import com.kakaotech.team14backend.common.RedisKey;
 import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +20,6 @@ import java.util.Set;
 
 @SpringBootTest
 @Sql(value = "classpath:db/teardown.sql")
-@DirtiesContext
 class SaveTemporaryPopularPostListUsecaseTest {
 
   @Autowired
@@ -28,6 +30,22 @@ class SaveTemporaryPopularPostListUsecaseTest {
 
   @Autowired
   private RedisTemplate redisTemplate;
+
+  @BeforeEach
+  void init_start(){
+    Set<String> keys = redisTemplate.keys("*");
+    if (keys != null && !keys.isEmpty()) {
+      redisTemplate.delete(keys);
+    }
+  }
+
+  @AfterEach
+  void init_end(){
+    Set<String> keys = redisTemplate.keys("*");
+    if (keys != null && !keys.isEmpty()) {
+      redisTemplate.delete(keys);
+    }
+  }
 
   @Test
   void execute() {


### PR DESCRIPTION
각 테스트의 독립성을 보장하기 위해 테스트에 맞게 Redis 관련 데이터를 삭제하거나 세팅하였습니다.

관련 이슈 : https://github.com/Step3-kakao-tech-campus/Team14_BE/issues/87