### PR TITLE
인기피드 - Post 엔티티에 인기도 레벨 컬럼 추가

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -65,11 +65,11 @@ public class Post {
   @Column(nullable = true)
   private Long popularity; // 인기도 값
 
-  @Column(nullable = false)
-  private Integer reportCount; // 제재 횟수
+  @Column(nullable = true)
+  private Integer postLevel; // 게시물 레벨
 
   @Column(nullable = false)
-  private Integer postPoint;
+  private Integer reportCount; // 제재 횟수
 
   @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
   private List<PostLike> postLikeHistories;
@@ -98,7 +98,6 @@ public class Post {
         .viewCount(0L)
         .popularity(0L)
         .reportCount(0)
-        .postPoint(0)
         .build();
     post.mappingPostLikeCount(postLikeCount);
     post.mappingMember(member);
@@ -109,7 +108,7 @@ public class Post {
 
   @Builder
   public Post(String nickname, Boolean published, String hashtag,
-      String university, Long viewCount, Long popularity, Integer reportCount, Integer postPoint) {
+      String university, Long viewCount, Long popularity, Integer reportCount) {
     this.nickname = nickname;
     this.createdAt = Instant.now();
     this.published = published;
@@ -118,7 +117,6 @@ public class Post {
     this.viewCount = viewCount;
     this.popularity = popularity;
     this.reportCount = reportCount;
-    this.postPoint = postPoint;
   }
 
   public void updateViewCount(Long viewCount) {
@@ -134,7 +132,10 @@ public class Post {
   public void updatePopularity(long likeCount, long postAge){
     long popularity = (likeCount + this.viewCount) / postAge;
     this.popularity = Long.valueOf(popularity);
-    System.out.println("popularity = " + popularity);
+  }
+
+  public void updatePostLevel(int postLevel) {
+    this.postLevel = postLevel;
   }
 
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/repository/PostRepository.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/repository/PostRepository.java
@@ -12,7 +12,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
   List<Post> findByPostIdGreaterThan(Long lastPostId, Pageable pageable);
 
-  @Query("SELECT new com.kakaotech.team14backend.outer.post.dto.GetIncompletePopularPostDTO(p.postId,i.imageUri,p.hashtag,pl.likeCount,p.postPoint,p.popularity,p.nickname) " +
+  @Query("SELECT new com.kakaotech.team14backend.outer.post.dto.GetIncompletePopularPostDTO(p.postId,i.imageUri,p.hashtag,pl.likeCount,p.popularity,p.nickname) " +
       "FROM Post p " +
       "JOIN p.image i " + // Image에 대한 JOIN
       "JOIN p.postLikeCount pl " + // PostLike에 대한 JOIN

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecase.java
@@ -2,6 +2,7 @@ package com.kakaotech.team14backend.inner.post.usecase;
 
 import com.kakaotech.team14backend.common.RedisKey;
 import com.kakaotech.team14backend.inner.post.model.PostRandomFetcher;
+import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import com.kakaotech.team14backend.outer.post.dto.GetIncompletePopularPostDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.mapper.PostMapper;
@@ -40,7 +41,6 @@ public class FindPopularPostListUsecase {
       for(int j = 0; j < levelIndexes.get(i).size(); j++){
 
         Set<LinkedHashMap<String, Object>> posts = redisTemplate.opsForZSet().range(RedisKey.POPULAR_POST_KEY.getKey(), levelIndexes.get(i).get(j)-1, levelIndexes.get(i).get(j)-1);
-        Long size = redisTemplate.opsForZSet().size(RedisKey.POPULAR_POST_KEY.getKey());
 
         List<GetIncompletePopularPostDTO> getIncompletePopularPostDTOs = getIncompletePopularPostDTOs(posts);
 
@@ -65,7 +65,7 @@ public class FindPopularPostListUsecase {
       String nickname = (String) postMap.get("nickname");
 
       return new GetIncompletePopularPostDTO(
-          postId, imageUri, hashTag, likeCount, postPoint, popularity, nickname
+          postId, imageUri, hashTag, likeCount, popularity, nickname
       );
     }).collect(Collectors.toList());
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePopularPostLevel.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePopularPostLevel.java
@@ -1,0 +1,23 @@
+package com.kakaotech.team14backend.inner.post.usecase;
+
+import com.kakaotech.team14backend.inner.post.repository.PostRepository;
+import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class UpdatePopularPostLevel {
+
+  private final PostRepository postRepository;
+
+  public void execute(GetPopularPostListResponseDTO getPopularPostListResponseDTO) {
+    getPopularPostListResponseDTO.popularPosts().forEach(getPopularPostDTO -> {
+      postRepository.findById(getPopularPostDTO.postId()).ifPresent(post -> {
+        post.updatePostLevel(getPopularPostDTO.postLevel());
+      });
+    });
+  }
+}

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetIncompletePopularPostDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetIncompletePopularPostDTO.java
@@ -11,16 +11,14 @@ public class GetIncompletePopularPostDTO {
   private String imageUri;
   private String hashTag;
   private Long likeCount;
-  private Integer postPoint;
   private Long popularity;
   private String nickname;
 
-  public GetIncompletePopularPostDTO(Long postId, String imageUri, String hashTag, Long likeCount, Integer postPoint, Long popularity, String nickname) {
+  public GetIncompletePopularPostDTO(Long postId, String imageUri, String hashTag, Long likeCount, Long popularity, String nickname) {
     this.postId = postId;
     this.imageUri = imageUri;
     this.hashTag = hashTag;
     this.likeCount = likeCount;
-    this.postPoint = postPoint;
     this.popularity = popularity;
     this.nickname = nickname;
   }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPopularPostDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPopularPostDTO.java
@@ -2,5 +2,5 @@ package com.kakaotech.team14backend.outer.post.dto;
 
 import java.util.List;
 
-public record GetPopularPostDTO(Long postId, String imageUri, List<String> hashTags, Long likeCount, Integer boardPoint, String nickname, Integer postLevel) {
+public record GetPopularPostDTO(Long postId, String imageUri, List<String> hashTags, Long likeCount, Integer postPoint, String nickname, Integer postLevel) {
 }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostResponseDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostResponseDTO.java
@@ -2,5 +2,5 @@ package com.kakaotech.team14backend.outer.post.dto;
 
 import java.util.List;
 
-public record GetPostResponseDTO(Long postId, String imageUri, List<String> hashTags, Long likeCount, Integer boardPoint, String nickname) {
+public record GetPostResponseDTO(Long postId, String imageUri, List<String> hashTags, Long likeCount, Integer postPoint, String nickname) {
 }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
@@ -48,10 +48,10 @@ public class PostMapper {
 
       for (GetIncompletePopularPostDTO incompletePost : incompletePosts) {
         List<String> hashTags = splitHashtag(incompletePost.getHashTag());
-        int boardPoint = 0;
+        int postPoint = 0;
 
         GetPopularPostDTO popularPost = new GetPopularPostDTO(incompletePost.getPostId(),
-            incompletePost.getImageUri(), hashTags, incompletePost.getLikeCount(), boardPoint,
+            incompletePost.getImageUri(), hashTags, incompletePost.getLikeCount(), postPoint,
             incompletePost.getNickname(), postLevel);
         popularPosts.add(popularPost);
       }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
@@ -12,6 +12,7 @@ import com.kakaotech.team14backend.inner.post.usecase.FindPostListUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.FindPostUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.SaveTemporaryPostViewCountUsecase;
 import com.kakaotech.team14backend.inner.post.usecase.SetPostLikeUsecase;
+import com.kakaotech.team14backend.inner.post.usecase.UpdatePopularPostLevel;
 import com.kakaotech.team14backend.inner.post.usecase.UpdatePostLikeCountUsecase;
 import com.kakaotech.team14backend.outer.post.dto.CreatePostDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPersonalPostListResponseDTO;
@@ -45,6 +46,7 @@ public class PostService {
   private final FindPopularPostListUsecase findPopularPostListUsecase;
   private final UpdatePostLikeCountUsecase updatePostLikeCountUsecase;
   private final FindPersonalPostListUsecase findPersonalPostListUsecase;
+  private final UpdatePopularPostLevel updatePopularPostLevel;
 
   public GetPersonalPostListResponseDTO getPersonalPostList(Long userId, Long lastPostId, int size) {
 
@@ -96,7 +98,7 @@ public class PostService {
     updatePostLikeCountUsecase.execute(getPostLikeCountDTO);
     return isLiked;
   }
-  
+
   /**
    * 인기 게시물 전체 조회
    *
@@ -107,6 +109,7 @@ public class PostService {
 
   public GetPopularPostListResponseDTO getPopularPostList(GetPopularPostListRequestDTO getPopularPostListRequestDTO){
     GetPopularPostListResponseDTO getPopularPostListResponseDTO = findPopularPostListUsecase.execute(getPopularPostListRequestDTO.levelSize());
+    updatePopularPostLevel.execute(getPopularPostListResponseDTO);
     return getPopularPostListResponseDTO;
   }
 

--- a/src/main/resources/db/teardown.sql
+++ b/src/main/resources/db/teardown.sql
@@ -27,28 +27,27 @@ VALUES (NOW(), 'image_uri1'),
 
 -- Post Table
 INSERT INTO post (created_at, nickname, popularity, published, report_count, university, view_count,
-                  post_point,
                   image_id, member_id, hashtag)
-VALUES (NOW(), 'nickname1', 100, true, 0, 'university1', 1000, 400, 1, 1, '#hashtag1'),
-       (NOW(), 'nickname2', 200, true, 1, 'university2', 2000, 400, 2, 2, '#hashtag2'),
-       (NOW(), 'nickname3', 300, false, 2, 'university3', 3000, 400, 3, 3, '#hashtag3'),
-       (NOW(), 'nickname4', 400, true, 3, 'university4', 4000, 400, 4, 1, '#hashtag4'),
-       (NOW(), 'nickname5', 500, false, 4, 'university5', 5000, 400, 5, 2, '#hashtag5'),
-       (NOW(), 'nickname6', 600, true, 5, 'university6', 6000, 400, 6, 3, '#hashtag6'),
-       (NOW(), 'nickname7', 700, false, 6, 'university7', 7000, 400, 7, 1, '#hashtag7'),
-       (NOW(), 'nickname8', 800, true, 7, 'university8', 8000, 400, 8, 2, '#hashtag8'),
-       (NOW(), 'nickname9', 900, false, 8, 'university9', 9000, 400, 9, 3, '#hashtag9'),
-       (NOW(), 'nickname10', 1000, true, 9, 'university10', 10000, 400, 10, 1, '#hashtag10'),
-       (NOW(), 'nickname11', 100, true, 0, 'university1', 1000, 400, 1, 1, '#hashtag1'),
-       (NOW(), 'nickname12', 200, true, 1, 'university2', 2000, 400, 2, 2, '#hashtag2'),
-       (NOW(), 'nickname13', 300, false, 2, 'university3', 3000, 400, 3, 3, '#hashtag3'),
-       (NOW(), 'nickname14', 400, true, 3, 'university4', 4000, 400, 4, 1, '#hashtag4'),
-       (NOW(), 'nickname15', 500, false, 4, 'university5', 5000, 400, 5, 2, '#hashtag5'),
-       (NOW(), 'nickname16', 600, true, 5, 'university6', 6000, 400, 6, 3, '#hashtag6'),
-       (NOW(), 'nickname17', 700, false, 6, 'university7', 7000, 400, 7, 1, '#hashtag7'),
-       (NOW(), 'nickname18', 800, true, 7, 'university8', 8000, 400, 8, 2, '#hashtag8'),
-       (NOW(), 'nickname19', 900, false, 8, 'university9', 9000, 400, 9, 3, '#hashtag9'),
-       (NOW(), 'nickname20', 1000, true, 9, 'university10', 10000, 400, 10, 1, '#hashtag10');
+VALUES (NOW(), 'nickname1', 100, true, 0, 'university1', 1000, 1, 1, '#hashtag1'),
+       (NOW(), 'nickname2', 200, true, 1, 'university2', 2000, 2, 2, '#hashtag2'),
+       (NOW(), 'nickname3', 300, false, 2, 'university3', 3000, 3, 3, '#hashtag3'),
+       (NOW(), 'nickname4', 400, true, 3, 'university4', 4000, 4, 1, '#hashtag4'),
+       (NOW(), 'nickname5', 500, false, 4, 'university5', 5000, 5, 2, '#hashtag5'),
+       (NOW(), 'nickname6', 600, true, 5, 'university6', 6000, 6, 3, '#hashtag6'),
+       (NOW(), 'nickname7', 700, false, 6, 'university7', 7000, 7, 1, '#hashtag7'),
+       (NOW(), 'nickname8', 800, true, 7, 'university8', 8000, 8, 2, '#hashtag8'),
+       (NOW(), 'nickname9', 900, false, 8, 'university9', 9000, 9, 3, '#hashtag9'),
+       (NOW(), 'nickname10', 1000, true, 9, 'university10', 10000, 10, 1, '#hashtag10'),
+       (NOW(), 'nickname11', 100, true, 0, 'university1', 1000, 1, 1, '#hashtag1'),
+       (NOW(), 'nickname12', 200, true, 1, 'university2', 2000, 2, 2, '#hashtag2'),
+       (NOW(), 'nickname13', 300, false, 2, 'university3', 3000, 3, 3, '#hashtag3'),
+       (NOW(), 'nickname14', 400, true, 3, 'university4', 4000, 4, 1, '#hashtag4'),
+       (NOW(), 'nickname15', 500, false, 4, 'university5', 5000, 5, 2, '#hashtag5'),
+       (NOW(), 'nickname16', 600, true, 5, 'university6', 6000, 6, 3, '#hashtag6'),
+       (NOW(), 'nickname17', 700, false, 6, 'university7', 7000, 7, 1, '#hashtag7'),
+       (NOW(), 'nickname18', 800, true, 7, 'university8', 8000, 8, 2, '#hashtag8'),
+       (NOW(), 'nickname19', 900, false, 8, 'university9', 9000, 9, 3, '#hashtag9'),
+       (NOW(), 'nickname20', 1000, true, 9, 'university10', 10000, 10, 1, '#hashtag10');
 
 -- Using UNION ALL to generate numbers up to 280
 WITH RECURSIVE numbers(val) AS (
@@ -59,7 +58,7 @@ WITH RECURSIVE numbers(val) AS (
     WHERE val < 280
 )
 
-INSERT INTO post (created_at, nickname, popularity, published, report_count, university, view_count, post_point, image_id, member_id, hashtag)
+INSERT INTO post (created_at, nickname, popularity, published, report_count, university, view_count, image_id, member_id, hashtag)
 SELECT
     NOW(),
     'nickname' || (val + 20),
@@ -68,7 +67,6 @@ SELECT
     0,
     'university' || ((val % 10) + 1),
     (val * 1000),
-    400,
     ((val % 10) + 1),
     ((val % 3) + 1),
     '#hashtag' || ((val % 10) + 1)

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecaseTest.java
@@ -42,7 +42,7 @@ class FindPopularPostListUsecaseTest {
     redisTemplate.delete(RedisKey.POPULAR_POST_KEY.getKey());
     List<Post> posts = postRepository.findAll();
     posts.forEach(post -> {
-      redisTemplate.opsForZSet().add(RedisKey.POPULAR_POST_KEY.getKey(),new GetIncompletePopularPostDTO(post.getPostId(),post.getImage().getImageUri(),post.getHashtag(),post.getPostLikeCount().getLikeCount(),post.getPostPoint(),post.getPopularity(),post.getNickname()),post.getPopularity());
+      redisTemplate.opsForZSet().add(RedisKey.POPULAR_POST_KEY.getKey(),new GetIncompletePopularPostDTO(post.getPostId(),post.getImage().getImageUri(),post.getHashtag(),post.getPostLikeCount().getLikeCount(),post.getPopularity(),post.getNickname()),post.getPopularity());
     });
   }
 


### PR DESCRIPTION
Post 엔티티에 인기도 레벨 컬럼을 추가하고, postPoint 컬럼을 제거하였습니다. 또한 인기도가 높은 상위 300개의 게시물을 인기도 레벨을 update하는 usecase를 생성하였습니다.

관련 이슈는 아래와 같습니다.

이슈 : https://github.com/Step3-kakao-tech-campus/Team14_BE/issues/95

## Commit 요약


### refactor : Post엔티티 변경사항으로 인해 teardown.sql 수정

### refactor : 엔티티와의 통일성을 위해 boardPoint -> pointPoint로 변경

### test : Post 엔티티에 게시물 인기 레벨을 업데이트하는 usecase 생성 및 해당 usecase를 postService의 getPopularPostList() 메서드에 추가
