### PR TITLE
example/unit-test-0 | 도메인 엔터티에 대한 유닛 테스트 예제

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -5,6 +5,8 @@ import static lombok.AccessLevel.PROTECTED;
 
 import com.kakaotech.team14backend.inner.image.model.Image;
 import com.kakaotech.team14backend.inner.member.model.Member;
+
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -142,7 +144,7 @@ public class Post {
   }
 
   private long measurePostAge(final Instant now) {
-    int time = now.compareTo(createdAt);
+    int time = Duration.between(createdAt, now).toHoursPart();
     return  time < 5 ? 1 : time / 5;
   }
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -140,7 +140,7 @@ public class Post {
   }
 
   private void updatePopularity(long likeCount, long postAge){
-    this.popularity = Long.valueOf((likeCount + this.viewCount) / postAge);
+    this.popularity = (likeCount + this.viewCount) / postAge;
     log.info("popularity = {}", this.popularity);
   }
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -128,11 +128,16 @@ public class Post {
   }
 
   public void updatePopularity() {
+    final long popularity = calculatePopularity();
+    this.popularity = popularity;
+    log.info("popularity = {}", this.popularity);
+  }
+
+  private long calculatePopularity() {
     Long likeCount = postLikeCount.getLikeCount();
     long postAge = measurePostAge();
     final long popularity = ((long) likeCount + viewCount) / postAge;
-    this.popularity = popularity;
-    log.info("popularity = {}", this.popularity);
+    return popularity;
   }
 
   private long measurePostAge() {

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -132,7 +132,7 @@ public class Post {
     log.info("popularity = {}", this.popularity);
   }
 
-  private long calculatePopularity() {
+  long calculatePopularity() {
     Long likeCount = postLikeCount.getLikeCount();
     long postAge = measurePostAge();
     return ((long) likeCount + viewCount) / postAge;

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -130,7 +130,7 @@ public class Post {
   public void updatePopularity() {
     Long likeCount = postLikeCount.getLikeCount();
     long postAge = measurePostAge();
-    updatePopularity(likeCount.longValue(), postAge);
+    updatePopularity(likeCount, postAge);
   }
 
   private long measurePostAge() {

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -128,16 +128,14 @@ public class Post {
   }
 
   public void updatePopularity() {
-    final long popularity = calculatePopularity();
-    this.popularity = popularity;
+    popularity = calculatePopularity();
     log.info("popularity = {}", this.popularity);
   }
 
   private long calculatePopularity() {
     Long likeCount = postLikeCount.getLikeCount();
     long postAge = measurePostAge();
-    final long popularity = ((long) likeCount + viewCount) / postAge;
-    return popularity;
+    return ((long) likeCount + viewCount) / postAge;
   }
 
   private long measurePostAge() {

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -138,4 +138,9 @@ public class Post {
   }
 
 
+  public void updatePopularity() {
+    Long likeCount = getPostLikeCount().getLikeCount();
+    long postAge = measurePostAge();
+    updatePopularity(likeCount.longValue(), postAge);
+  }
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -130,8 +130,9 @@ public class Post {
   public void updatePopularity() {
     Long likeCount = postLikeCount.getLikeCount();
     long postAge = measurePostAge();
-    popularity = ((long) likeCount + viewCount) / postAge;
-    log.info("popularity = {}", popularity);
+    final long popularity = ((long) likeCount + viewCount) / postAge;
+    this.popularity = popularity;
+    log.info("popularity = {}", this.popularity);
   }
 
   private long measurePostAge() {

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -139,7 +139,7 @@ public class Post {
 
 
   public void updatePopularity() {
-    Long likeCount = getPostLikeCount().getLikeCount();
+    Long likeCount = postLikeCount.getLikeCount();
     long postAge = measurePostAge();
     updatePopularity(likeCount.longValue(), postAge);
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team14backend.inner.post.model;
 
+import static lombok.AccessLevel.PACKAGE;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.kakaotech.team14backend.inner.image.model.Image;
@@ -20,12 +21,14 @@ import javax.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Entity
 @NoArgsConstructor(access = PROTECTED)
 @Getter
+@Setter(PACKAGE)
 public class Post {
 
   // Primary Key
@@ -127,19 +130,18 @@ public class Post {
     this.viewCount = viewCount;
   }
 
-  public void updatePopularity() {
-    popularity = calculatePopularity();
+  public void updatePopularity(final Instant now) {
+    popularity = calculatePopularity(now);
     log.info("popularity = {}", this.popularity);
   }
 
-  long calculatePopularity() {
+  long calculatePopularity(final Instant now) {
     Long likeCount = postLikeCount.getLikeCount();
-    long postAge = measurePostAge();
+    long postAge = measurePostAge(now);
     return ((long) likeCount + viewCount) / postAge;
   }
 
-  private long measurePostAge() {
-    Instant now = Instant.now();
+  private long measurePostAge(final Instant now) {
     int time = now.compareTo(createdAt);
     return  time < 5 ? 1 : time / 5;
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -20,7 +20,9 @@ import javax.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Entity
 @NoArgsConstructor(access = PROTECTED)
 @Getter
@@ -140,7 +142,7 @@ public class Post {
   private void updatePopularity(long likeCount, long postAge){
     long popularity = (likeCount + this.viewCount) / postAge;
     this.popularity = Long.valueOf(popularity);
-    System.out.println("popularity = " + popularity);
+    log.info("popularity = {}", this.popularity);
   }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -144,8 +144,8 @@ public class Post {
   }
 
   private long measurePostAge(final Instant now) {
-    int time = Duration.between(createdAt, now).toHoursPart();
-    return  time < 5 ? 1 : time / 5;
+    int hours = Duration.between(createdAt, now).toHoursPart();
+    return  hours < 5 ? 1 : hours / 5;
   }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -130,18 +130,14 @@ public class Post {
   public void updatePopularity() {
     Long likeCount = postLikeCount.getLikeCount();
     long postAge = measurePostAge();
-    updatePopularity(likeCount, postAge);
+    popularity = ((long) likeCount + viewCount) / postAge;
+    log.info("popularity = {}", popularity);
   }
 
   private long measurePostAge() {
     Instant now = Instant.now();
     int time = now.compareTo(createdAt);
     return  time < 5 ? 1 : time / 5;
-  }
-
-  private void updatePopularity(long likeCount, long postAge){
-    popularity = (likeCount + viewCount) / postAge;
-    log.info("popularity = {}", popularity);
   }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -135,13 +135,13 @@ public class Post {
 
   private long measurePostAge() {
     Instant now = Instant.now();
-    int time = now.compareTo(this.createdAt);
+    int time = now.compareTo(createdAt);
     return  time < 5 ? 1 : time / 5;
   }
 
   private void updatePopularity(long likeCount, long postAge){
-    this.popularity = (likeCount + this.viewCount) / postAge;
-    log.info("popularity = {}", this.popularity);
+    popularity = (likeCount + viewCount) / postAge;
+    log.info("popularity = {}", popularity);
   }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -140,8 +140,7 @@ public class Post {
   }
 
   private void updatePopularity(long likeCount, long postAge){
-    long popularity = (likeCount + this.viewCount) / postAge;
-    this.popularity = Long.valueOf(popularity);
+    this.popularity = Long.valueOf((likeCount + this.viewCount) / postAge);
     log.info("popularity = {}", this.popularity);
   }
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -125,6 +125,12 @@ public class Post {
     this.viewCount = viewCount;
   }
 
+  public void updatePopularity() {
+    Long likeCount = postLikeCount.getLikeCount();
+    long postAge = measurePostAge();
+    updatePopularity(likeCount.longValue(), postAge);
+  }
+
   private long measurePostAge() {
     Instant now = Instant.now();
     int time = now.compareTo(this.createdAt);
@@ -137,10 +143,4 @@ public class Post {
     System.out.println("popularity = " + popularity);
   }
 
-
-  public void updatePopularity() {
-    Long likeCount = postLikeCount.getLikeCount();
-    long postAge = measurePostAge();
-    updatePopularity(likeCount.longValue(), postAge);
-  }
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/Post.java
@@ -125,13 +125,13 @@ public class Post {
     this.viewCount = viewCount;
   }
 
-  public long measurePostAge() {
+  private long measurePostAge() {
     Instant now = Instant.now();
     int time = now.compareTo(this.createdAt);
     return  time < 5 ? 1 : time / 5;
   }
 
-  public void updatePopularity(long likeCount, long postAge){
+  private void updatePopularity(long likeCount, long postAge){
     long popularity = (likeCount + this.viewCount) / postAge;
     this.popularity = Long.valueOf(popularity);
     System.out.println("popularity = " + popularity);

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
@@ -18,10 +18,14 @@ public class UpdatePostPopularityUsecase {
   public void execute() {
     List<Post> posts = postRepository.findAll();
     for (Post post : posts) {
-      Long likeCount = post.getPostLikeCount().getLikeCount();
-      long postAge = post.measurePostAge();
-      post.updatePopularity(likeCount.longValue(), postAge);
+      updatePopularity(post);
       postRepository.save(post);
     }
+  }
+
+  private void updatePopularity(final Post post) {
+    Long likeCount = post.getPostLikeCount().getLikeCount();
+    long postAge = post.measurePostAge();
+    post.updatePopularity(likeCount.longValue(), postAge);
   }
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.transaction.Transactional;
+import java.time.Instant;
 import java.util.List;
 
 @Component
@@ -18,7 +19,7 @@ public class UpdatePostPopularityUsecase {
   public void execute() {
     List<Post> posts = postRepository.findAll();
     for (Post post : posts) {
-      post.updatePopularity();
+      post.updatePopularity(Instant.now());
       postRepository.save(post);
     }
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
@@ -17,9 +17,10 @@ public class UpdatePostPopularityUsecase {
 
   @Transactional
   public void execute() {
+    final Instant now = Instant.now();
     List<Post> posts = postRepository.findAll();
     for (Post post : posts) {
-      post.updatePopularity(Instant.now());
+      post.updatePopularity(now);
       postRepository.save(post);
     }
   }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostPopularityUsecase.java
@@ -18,14 +18,9 @@ public class UpdatePostPopularityUsecase {
   public void execute() {
     List<Post> posts = postRepository.findAll();
     for (Post post : posts) {
-      updatePopularity(post);
+      post.updatePopularity();
       postRepository.save(post);
     }
   }
 
-  private void updatePopularity(final Post post) {
-    Long likeCount = post.getPostLikeCount().getLikeCount();
-    long postAge = post.measurePostAge();
-    post.updatePopularity(likeCount.longValue(), postAge);
-  }
 }

--- a/src/test/java/com/kakaotech/team14backend/inner/post/model/PostTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/model/PostTest.java
@@ -10,14 +10,14 @@ import java.time.ZoneId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PostTest {
+  private final long likeCount = 100L;
+  private final long viewCount = 1000L;
+  private final LocalDateTime postCreatedAt = LocalDateTime.of(2023, 10, 10, 18, 0, 0);
 
   @Test
   @DisplayName("좋아요 100, 조회수 1000, 생성으로부터 1시간 경과했을 때 인기도는 1100이다.")
   void calculatePopularity_case_0() {
     // given
-    final var likeCount = 100L;
-    final var viewCount = 1000L;
-    final var postCreatedAt = LocalDateTime.of(2023, 10, 10, 18, 0, 0);
     final var now = postCreatedAt.plusHours(1);
     final var post = createPostWith(likeCount, viewCount, postCreatedAt);
 

--- a/src/test/java/com/kakaotech/team14backend/inner/post/model/PostTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/model/PostTest.java
@@ -28,6 +28,20 @@ class PostTest {
     assertThat(popularity).isEqualTo(1100L);
   }
 
+  @Test
+  @DisplayName("좋아요 100, 조회수 1000, 생성으로부터 10시간 경과했을 때 인기도는 550이다.")
+  void calculatePopularity_case_1() {
+    // given
+    final var now = postCreatedAt.plusHours(10);
+    final var post = createPostWith(likeCount, viewCount, postCreatedAt);
+
+    // when
+    final long popularity = post.calculatePopularity(toInstant(now));
+
+    // then
+    assertThat(popularity).isEqualTo(550L);
+  }
+
   private Post createPostWith(final long likeCount, final long viewCount, final LocalDateTime postCreatedAt) {
     final var count = new PostLikeCount();
     count.updateLikeCount(likeCount);

--- a/src/test/java/com/kakaotech/team14backend/inner/post/model/PostTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/model/PostTest.java
@@ -1,0 +1,44 @@
+package com.kakaotech.team14backend.inner.post.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostTest {
+
+  @Test
+  @DisplayName("좋아요 100, 조회수 1000, 생성으로부터 1시간 경과했을 때 인기도는 1100이다.")
+  void calculatePopularity_case_0() {
+    // given
+    final var likeCount = 100L;
+    final var viewCount = 1000L;
+    final var postCreatedAt = LocalDateTime.of(2023, 10, 10, 18, 0, 0);
+    final var now = postCreatedAt.plusHours(1);
+    final var post = createPostWith(likeCount, viewCount, postCreatedAt);
+
+    // when
+    final long popularity = post.calculatePopularity(toInstant(now));
+
+    // then
+    assertThat(popularity).isEqualTo(1100L);
+  }
+
+  private Post createPostWith(final long likeCount, final long viewCount, final LocalDateTime postCreatedAt) {
+    final var count = new PostLikeCount();
+    count.updateLikeCount(likeCount);
+    final var post = new Post();
+    post.setPostLikeCount(count);
+    post.setViewCount(viewCount);
+    post.setCreatedAt(toInstant(postCreatedAt));
+    return post;
+  }
+
+  private Instant toInstant(final LocalDateTime dateTime) {
+    return dateTime.atZone(ZoneId.systemDefault()).toInstant();
+  }
+}


### PR DESCRIPTION
## Description
- 이 PR은 merge 하지 않음. 유닛 테스트 예제일 뿐.
- 로직을 도메인 엔터티로 보내서 응집도를 높임. [Tell Don't Ask](https://martinfowler.com/bliki/TellDontAsk.html)
- 리팩터링 과정은 커밋 메세지 참조.
- 리팩터링을 통해 테스트 불가능(시간 의존)한 기존 로직에서 테스트 가능한 도메인 로직을 만들고 유닛 테스트 추가.
- 비슷한 예제를 [단위 테스트](https://www.aladin.co.kr/shop/wproduct.aspx?ItemId=280870631) 저자 블로그에서 볼 수 있음: [Domain model purity and the current time](https://enterprisecraftsmanship.com/posts/domain-model-purity-current-time/)
- "현재 시간"에 의존하는 로직은 테스트 불가능함. 따라서 현재 시간을 명시적 파라미터로 바꾸면 non-deterministic 한 메서드를 deterministic 하게 만들 수 있음.
- updatePopularity 메서드에서 계산하는 부분만 분리해서 calculatePopularity 메서드를 만듦. 이렇게 하면 상태 기반 테스트에서 결과 기반 테스트가 되어 더 테스트 하기 쉬움. CQS(command-query seperation)을 적용.
- measurePostAge 메서드는 아마 버그이거나 임시 코드로 보임. time을 경과된 시간(hour)이라고 가정하고 테스트 케이스를 만듦.

## Tell, Don't Ask
- 묻지 말고 시켜라.
- 자판기를 예로 들면, 동전을 넣고 음료를 고르면 알아서 음료와 잔돈이 나옴. 우리는 음료의 재고가 몇개 남았는지, 잔돈 계산을 어떻게 하는지 물어보지 않음. OOP 관점에서 클래스는 수동적이기보다 자율적이어야하고, 로직은 클래스 내부로 추상화 되어 있어야 함.  
- 기존 코드에서는 도메인 객체에게 postAge와 likeCount를 물어봄. 하지만 모두 객체 내부에서 구할 수 있는 값임. 따라서 리팩터링을 통해 로직을 클래스 내부로 이동(extract method -> move instance method).


![sketch](https://github.com/Step3-kakao-tech-campus/Team14_BE/assets/5006605/e38a71df-1a58-46cb-9576-31c5bada3a9e)

