### PR TITLE
예외 처리 전략 변경

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/common/FileUtils.java
+++ b/src/main/java/com/kakaotech/team14backend/common/FileUtils.java
@@ -27,18 +27,6 @@ public class FileUtils {
     return fileDir + filename;
   }
 
-  public List<UploadFileDTO> storeFiles(List<MultipartFile> multipartFiles) throws IOException {
-    List<UploadFileDTO> storeFileResult = new ArrayList<>();
-    for (MultipartFile multipartFile : multipartFiles) {
-      if (!multipartFile.isEmpty()) {
-        storeFileResult.add(storeFile(multipartFile));
-      } else {
-        throw new FileNotFoundException();
-      }
-    }
-    return storeFileResult;
-  }
-
   public UploadFileDTO storeFile(MultipartFile multipartFile)
       throws IOException, IllegalStateException {
     if (multipartFile.isEmpty()) {
@@ -68,16 +56,5 @@ public class FileUtils {
     return ext;
   }
 
-  public MediaType toMediaType(String ext) {
-    MediaType mediaType = MediaType.ALL;
-    if (ext.equals("jpg") || ext.equals("jpeg")) {
-      mediaType = MediaType.IMAGE_JPEG;
-    } else if (ext.equals("png")) {
-      mediaType = MediaType.IMAGE_PNG;
-    } else if (ext.equals("pdf")) {
-      mediaType = MediaType.APPLICATION_PDF;
-    }
-    return mediaType;
-  }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/common/MessageCode.java
+++ b/src/main/java/com/kakaotech/team14backend/common/MessageCode.java
@@ -3,14 +3,21 @@ package com.kakaotech.team14backend.common;
 
 public enum MessageCode {
 
-  NOT_ALLOWED_FILE_EXT("4003","파일 확장명은 pdf,img만 가능합니다."),
+  NOT_ALLOWED_FILE_EXT("4003","파일 확장명은 pdf, jpg, jpeg, png만 가능합니다."),
   INVALIDATE_REFRESH_TOKEN("401","잘못된 리프레시 토큰입니다."),
   INVALIDATE_ACCESS_TOKEN("401","잘못된 엑세스 토큰입니다.")
   ,
   INCORRECT_REFRESH_TOEKN("401","요청된 리프레시토큰과 불일치합니다")
-,
+  ,
   NOT_REGISTER_MEMBER("401","회원정보가 존재하지 않습니다")
-  ,;
+  ,
+  LEVEL_SIZE_SMALLER_THAN_20("403","각 레벨당 사이즈는 20보다 작아야합니다."),
+
+  NOT_REGISTER_POST("444","해당 게시물이 존재하지 않습니다."),
+
+  POST_MUST_FOUND_ONE("888","게시물이 1개만 조회되어야 합니다.")
+
+  ;
 
   private final String code;
   private final String value;

--- a/src/main/java/com/kakaotech/team14backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/GlobalExceptionHandler.java
@@ -2,11 +2,40 @@ package com.kakaotech.team14backend.exception;
 
 import com.kakaotech.team14backend.common.ApiResponse;
 import com.kakaotech.team14backend.common.ApiResponseGenerator;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  @ExceptionHandler(MemberNotFoundException.class)
+  public ApiResponse<ApiResponse.CustomBody> handleMemberNotFoundException(MemberNotFoundException memberNotFoundException) {
+    return ApiResponseGenerator.fail(memberNotFoundException.getMessageCode().getCode(), memberNotFoundException.getMessageCode().getValue(), HttpStatus.BAD_REQUEST);
+  }
+  @ExceptionHandler(ExtentionNotAllowedException.class)
+  public ApiResponse<ApiResponse.CustomBody> handleMemberNotFoundException(ExtentionNotAllowedException extentionNotAllowedException) {
+    return ApiResponseGenerator.fail(extentionNotAllowedException.getMessageCode().getCode(), extentionNotAllowedException.getMessageCode().getValue(), HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(PostNotFoundException.class)
+  public ApiResponse<ApiResponse.CustomBody> handleMemberNotFoundException(PostNotFoundException postNotFoundException) {
+    return ApiResponseGenerator.fail(postNotFoundException.getMessageCode().getCode(), postNotFoundException.getMessageCode().getValue(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(MaxLevelSizeException.class)
+  public ApiResponse<ApiResponse.CustomBody> handleMemberNotFoundException(MaxLevelSizeException maxLevelSizeException) {
+    return ApiResponseGenerator.fail(maxLevelSizeException.getMessageCode().getCode(), maxLevelSizeException.getMessageCode().getValue(), HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(MultiplePostsFoundException.class)
+  public ApiResponse<ApiResponse.CustomBody> handleMemberNotFoundException(MultiplePostsFoundException multiplePostsFoundException) {
+    return ApiResponseGenerator.fail(multiplePostsFoundException.getMessageCode().getCode(), multiplePostsFoundException.getMessageCode().getValue(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+
+
+
 
   private static final String EXCEPTION_400_CODE = "400";
   private static final String EXCEPTION_401_CODE = "401";

--- a/src/main/java/com/kakaotech/team14backend/exception/MaxLevelSizeException.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/MaxLevelSizeException.java
@@ -1,0 +1,15 @@
+package com.kakaotech.team14backend.exception;
+
+import com.kakaotech.team14backend.common.MessageCode;
+import lombok.Getter;
+
+@Getter
+public class MaxLevelSizeException extends RuntimeException {
+
+  public final MessageCode messageCode;
+
+  public MaxLevelSizeException(MessageCode messageCode) {
+    this.messageCode = messageCode;
+  }
+
+}

--- a/src/main/java/com/kakaotech/team14backend/exception/MemberNotFoundException.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/MemberNotFoundException.java
@@ -1,7 +1,9 @@
 package com.kakaotech.team14backend.exception;
 
 import com.kakaotech.team14backend.common.MessageCode;
+import lombok.Getter;
 
+@Getter
 public class MemberNotFoundException extends RuntimeException{
   public final MessageCode messageCode;
 
@@ -9,8 +11,4 @@ public class MemberNotFoundException extends RuntimeException{
     this.messageCode = messageCode;
   }
 
-
-  public MemberNotFoundException(MessageCode messageCode, Exception e) {
-    this.messageCode = messageCode;
-  }
 }

--- a/src/main/java/com/kakaotech/team14backend/exception/MultiplePostsFoundException.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/MultiplePostsFoundException.java
@@ -1,0 +1,15 @@
+package com.kakaotech.team14backend.exception;
+
+import com.kakaotech.team14backend.common.MessageCode;
+import lombok.Getter;
+
+@Getter
+public class MultiplePostsFoundException extends RuntimeException{
+
+  public final MessageCode messageCode;
+
+  public MultiplePostsFoundException(MessageCode messageCode) {
+    this.messageCode = messageCode;
+  }
+
+}

--- a/src/main/java/com/kakaotech/team14backend/exception/PostNotFoundException.java
+++ b/src/main/java/com/kakaotech/team14backend/exception/PostNotFoundException.java
@@ -1,0 +1,14 @@
+package com.kakaotech.team14backend.exception;
+
+import com.kakaotech.team14backend.common.MessageCode;
+import lombok.Getter;
+
+@Getter
+public class PostNotFoundException extends RuntimeException{
+  
+  public final MessageCode messageCode;
+  public PostNotFoundException(MessageCode messageCode) {
+    this.messageCode = messageCode;
+  }
+
+}

--- a/src/main/java/com/kakaotech/team14backend/inner/member/usecase/FindMemberUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/member/usecase/FindMemberUsecase.java
@@ -1,5 +1,7 @@
 package com.kakaotech.team14backend.inner.member.usecase;
 
+import com.kakaotech.team14backend.common.MessageCode;
+import com.kakaotech.team14backend.exception.MemberNotFoundException;
 import com.kakaotech.team14backend.inner.member.model.Member;
 import com.kakaotech.team14backend.inner.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +15,7 @@ public class FindMemberUsecase {
 
   public Member execute(Long memberId) {
     return memberRepository.findById(memberId).orElseThrow(
-        () -> new RuntimeException("Member not found")
-    );
+        () -> new MemberNotFoundException(MessageCode.NOT_REGISTER_MEMBER));
   }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostUsecase.java
@@ -1,5 +1,7 @@
 package com.kakaotech.team14backend.inner.post.usecase;
 
+import com.kakaotech.team14backend.common.MessageCode;
+import com.kakaotech.team14backend.exception.MemberNotFoundException;
 import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import com.kakaotech.team14backend.outer.post.dto.GetPostDTO;
@@ -28,7 +30,7 @@ public class FindPopularPostUsecase {
 
   @Transactional(readOnly = true)
   public GetPostResponseDTO execute(GetPostDTO getPostDTO) {
-    Post popularPost = postRepository.findById(getPostDTO.postId()).orElseThrow(() -> new RuntimeException("Post not found"));
+    Post popularPost = postRepository.findById(getPostDTO.postId()).orElseThrow(() -> new MemberNotFoundException(MessageCode.NOT_REGISTER_MEMBER));
     GetPostResponseDTO getPostResponseDTO = PostMapper.from(popularPost);
     return getPostResponseDTO;
   }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
@@ -3,7 +3,9 @@ package com.kakaotech.team14backend.outer.post.controller;
 import com.kakaotech.team14backend.common.ApiResponse;
 import com.kakaotech.team14backend.common.ApiResponse.CustomBody;
 import com.kakaotech.team14backend.common.ApiResponseGenerator;
+import com.kakaotech.team14backend.common.MessageCode;
 import com.kakaotech.team14backend.exception.Exception400;
+import com.kakaotech.team14backend.exception.MaxLevelSizeException;
 import com.kakaotech.team14backend.outer.post.dto.GetPersonalPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListRequestDTO;
 import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListResponseDTO;
@@ -100,7 +102,7 @@ public class PostController {
       @RequestParam Integer level1, @RequestParam Integer level2, @RequestParam Integer level3) {
 
     if (level1 >= 20 | level2 >= 20 | level3 >= 20) {
-      throw new Exception400("Level size must be smaller than 20");
+      throw new MaxLevelSizeException(MessageCode.LEVEL_SIZE_SMALLER_THAN_20);
     }
 
     Map<Integer, Integer> levelSize = new HashMap<>();


### PR DESCRIPTION
기존의 예외를 Http Status별로 정의하는 방식에서 예외를 따로따로 나누는 방식으로 변경하였습니다.

1.  exception 패키지에서 예외를 정의
2. 해당 예외에 맞는 MessageCode 생성
3. 각 layer에서 예외 발생
4. GlobalExceptionHandle에서 예외 핸들링 메서드 생성

관련 이슈 : https://github.com/Step3-kakao-tech-campus/Team14_BE/issues/123

todo : 각자 맞은 기능을 위의 예외 처리 방식으로 변경해주세요!
