### PR TITLE
refactor : 이미지 경로 없을 시 생성하도록 수정

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/common/FileUtils.java
+++ b/src/main/java/com/kakaotech/team14backend/common/FileUtils.java
@@ -1,17 +1,13 @@
 package com.kakaotech.team14backend.common;
 
 import com.kakaotech.team14backend.exception.ExtentionNotAllowedException;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 @Component
 @Slf4j
@@ -32,6 +28,11 @@ public class FileUtils {
     if (multipartFile.isEmpty()) {
       return null;
     }
+    File directory = new File(fileDir);
+    if (!directory.exists()) {
+      directory.mkdirs();
+    }
+
     String originalFilename = multipartFile.getOriginalFilename();
     String storeFileName = createStoreFileName(originalFilename);
     multipartFile.transferTo(new File(getFullPath(storeFileName)));

--- a/src/main/java/com/kakaotech/team14backend/inner/image/model/Image.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/image/model/Image.java
@@ -2,9 +2,12 @@ package com.kakaotech.team14backend.inner.image.model;
 
 import static lombok.AccessLevel.PROTECTED;
 
-import com.kakaotech.team14backend.inner.post.model.Post;
-import javax.persistence.*;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,21 +16,21 @@ import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Getter
-@NoArgsConstructor(access=PROTECTED)
+@NoArgsConstructor(access = PROTECTED)
 public class Image {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long imageId; // 사진 ID
 
-  @Column(nullable = false, length = 20)
+  @Column(nullable = false, length = 100)
   private String imageUri; // 서버용 사진 저장 이름
 
   @Column(nullable = false)
   @CreationTimestamp
   private LocalDateTime createdAt; // 생성일
 
-  public static Image createImage(String imageUri){
+  public static Image createImage(String imageUri) {
     return Image.builder()
         .imageUri(imageUri)
         .build();


### PR DESCRIPTION
1. 이미지 경로가 없는 경우 예외 처리가 안되어 있음
2. 이미지 도메인의 엔티티가 20자로 제한이 되어 있어, 이미지 이름이 길면 받지 않는 이슈가 있음

이슈 번호 : #130 