### PR TITLE
FindPostListUsecase에서 랜덤 포스트 선택과 페이지네이션 구현

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPostListUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPostListUsecase.java
@@ -4,6 +4,8 @@ import com.kakaotech.team14backend.inner.post.model.Post;
 import com.kakaotech.team14backend.inner.post.repository.PostRepository;
 import com.kakaotech.team14backend.outer.post.dto.GetPostListResponseDTO;
 import com.kakaotech.team14backend.outer.post.mapper.PostMapper;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -21,27 +23,29 @@ public class FindPostListUsecase {
   /**
    * 홈 피드의 게시글들을 가져오는 유즈케이스. lastPostId와 size를 사용하여 페이지네이션을 지원합니다.
    */
-  public GetPostListResponseDTO excute(Long lastPostId, int size) {
-    Pageable pageable = PageRequest.of(0, size+1);  // 첫 페이지에 대한 요청, 페이지 크기는 10
-
+  public GetPostListResponseDTO execute(Long lastPostId, int size) {
+    Pageable pageable = PageRequest.of(0, size * 2 + 1);  // 첫 페이지에 대한 요청, 페이지 크기는 10
     List<Post> postList;
+    boolean hasNext = false;
 
     // lastPostId가 null인지 확인 (첫 페이지를 가져오는 것을 나타냄)
     // 그렇지 않으면 lastPostId를 기반으로 다음 페이지를 가져옴
     if (lastPostId == null) {
-      postList = postRepository.findAll(pageable).getContent();
+      postList = new ArrayList<>(postRepository.findAll(pageable).getContent());
     } else {
-      postList = postRepository.findNextPosts(lastPostId, pageable);
-    }
-    System.out.println("postList = " + postList);
-    boolean hasNext = false;
-    // 가져온 게시물 수가 요청된 크기보다 큰지 확인
-    // 참이면 hasNext 플래그를 true로 설정하고 목록을 요청된 크기로 자름
-    if (postList.size() > size) {
-      hasNext = true;
-      postList = postList.subList(0, size);  // postList를 업데이트하려면 할당이 필요합니다.
+      postList = new ArrayList<>(postRepository.findNextPosts(lastPostId, pageable));
     }
 
-    return new GetPostListResponseDTO(PostMapper.from(postList), hasNext);
+    if (postList.size() > size) {
+      hasNext = true;
+      lastPostId = postList.get(size * 2).getPostId();
+    } else {
+      lastPostId = null;
+    }
+
+    Collections.shuffle(postList);
+    List<Post> selectedPosts = postList.subList(0, size);
+
+    return new GetPostListResponseDTO(lastPostId, PostMapper.from(selectedPosts), hasNext);
   }
 }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostListResponseDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/dto/GetPostListResponseDTO.java
@@ -2,6 +2,7 @@ package com.kakaotech.team14backend.outer.post.dto;
 
 import java.util.List;
 
-public record GetPostListResponseDTO(List<GetPostResponseDTO> postList, Boolean hasNext) {
+public record GetPostListResponseDTO(Long lastPostId, List<GetPostResponseDTO> postList,
+                                     Boolean hasNext) {
 
 }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
@@ -46,7 +46,8 @@ public class PostService {
   private final UpdatePostLikeCountUsecase updatePostLikeCountUsecase;
   private final FindPersonalPostListUsecase findPersonalPostListUsecase;
 
-  public GetPersonalPostListResponseDTO getPersonalPostList(Long userId, Long lastPostId, int size) {
+  public GetPersonalPostListResponseDTO getPersonalPostList(Long userId, Long lastPostId,
+                                                            int size) {
 
     return findPersonalPostListUsecase.excute(userId, lastPostId, size);
   }
@@ -68,7 +69,7 @@ public class PostService {
   }
 
   public GetPostListResponseDTO getPostList(Long lastPostId, int size) {
-    return findPostListUsecase.excute(lastPostId, size);
+    return findPostListUsecase.execute(lastPostId, size);
   }
 
   /**
@@ -106,9 +107,9 @@ public class PostService {
   /**
    * 인기 게시물 전체 조회
    *
-   * @author : hwangdaesun
    * @param : 레벨별 게시물 size
    * @return : 인기 게시물들 응답
+   * @author : hwangdaesun
    */
 
   public GetPopularPostListResponseDTO getPopularPostList(


### PR DESCRIPTION

## 변경 사항
- 클라이언트로부터 요청받은 페이지네이션 크기를 처리하기 위해 동적 size 파라미터를 추가하였습니다.
- 원본 포스트 리스트를 셔플하지 않고 랜덤 포스트 선택을 구현하기 위해 새로운 메서드를 사용하였습니다.
- 현재 페이지네이션된 리스트를 기반으로 다음 페이지에 대한 lastPostId를 가져오는 로직을 업데이트하였습니다.
- 페이지네이트할 더 이상의 포스트가 없을 때 lastPostId를 null로 설정하도록 했습니다.
- 포스트 리스트 크기가 요청된 크기보다 작은 경우를 처리하기 위해 로직을 조정하였습니다.
- lastPostId, 랜덤으로 선택된 포스트, 그리고 hasNext 플래그를 포함하여 반환문을 업데이트하였습니다.
