### PR TITLE
Fix : User Info User Null 이슈 해결 및 Mock Up setting 변경

### DIFF
--- a/k8s/configs/default.conf
+++ b/k8s/configs/default.conf
@@ -2,10 +2,7 @@ server {
 	listen 80;
     location / {
         proxy_pass http://backend.default.svc.cluster.local:8080;
-
-	}
-	location /api/post/{
-        proxy_pass http://backend.default.svc.cluster.local:8080/api/post/;
     	client_max_body_size 100M;
 	}
+
 }

--- a/src/main/java/com/kakaotech/team14backend/outer/member/controller/MemberController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.kakaotech.team14backend.outer.member.controller;
 
+import com.kakaotech.team14backend.auth.PrincipalDetails;
 import com.kakaotech.team14backend.common.ApiResponse;
 import com.kakaotech.team14backend.common.ApiResponseGenerator;
 import com.kakaotech.team14backend.outer.member.dto.GetMemberInfoResponseDTO;
@@ -7,6 +8,7 @@ import com.kakaotech.team14backend.outer.member.service.MemberService;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,9 +22,9 @@ public class MemberController {
 
   @ApiOperation(value = "마이페이지 계정 상세 조회")
   @GetMapping("/user/info")
-  public ApiResponse<ApiResponse.CustomBody<GetMemberInfoResponseDTO>> getMyPageInfo() {
-    Long memberId = 1L;
-
+  public ApiResponse<ApiResponse.CustomBody<GetMemberInfoResponseDTO>> getMyPageInfo(
+      @AuthenticationPrincipal PrincipalDetails principalDetails) {
+    Long memberId = principalDetails.getMember().getMemberId();
     GetMemberInfoResponseDTO myPageInfo = memberService.getMyPageInfo(memberId);
     return ApiResponseGenerator.success(myPageInfo, HttpStatus.OK);
   }

--- a/src/main/java/com/kakaotech/team14backend/outer/member/controller/MemberController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/member/controller/MemberController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class MemberController {
 
-  private MemberService memberService;
+  private final MemberService memberService;
 
   @ApiOperation(value = "마이페이지 계정 상세 조회")
   @GetMapping("/user/info")

--- a/src/main/java/com/kakaotech/team14backend/outer/member/dto/GetMemberInfoResponseDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/member/dto/GetMemberInfoResponseDTO.java
@@ -1,7 +1,5 @@
 package com.kakaotech.team14backend.outer.member.dto;
 
-import lombok.Builder;
-
 public record GetMemberInfoResponseDTO(Long memberId, String userName, String kakaoId,
                                        Long totalLike,
                                        String profileImageUrl) {

--- a/src/main/java/com/kakaotech/team14backend/outer/member/dto/GetMemberInfoResponseDTO.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/member/dto/GetMemberInfoResponseDTO.java
@@ -2,22 +2,11 @@ package com.kakaotech.team14backend.outer.member.dto;
 
 import lombok.Builder;
 
-public class GetMemberInfoResponseDTO {
+public record GetMemberInfoResponseDTO(Long memberId, String userName, String kakaoId,
+                                       Long totalLike,
+                                       String profileImageUrl) {
 
-  private Long memberId;
-  private String userName;
-  private String kakaoId;
-  private Long totalLike;
-  private String profileImageUrl;
 
-  @Builder
-  public GetMemberInfoResponseDTO(Long memberId, String userName, String kakaoId, Long totalLike, String profileImageUrl) {
-    this.memberId = memberId;
-    this.userName = userName;
-    this.kakaoId = kakaoId;
-    this.totalLike = totalLike;
-    this.profileImageUrl = profileImageUrl;
-  }
 }
 
 

--- a/src/main/java/com/kakaotech/team14backend/outer/member/service/MemberService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/member/service/MemberService.java
@@ -20,17 +20,10 @@ public class MemberService {
   private final MemberRepository memberRepository; // 추후 Usecase 로 변경
 
   public static Member createMember(String userName, String kakaoId, String instaId,
-                                    String profileImageUrl, Role role,
-                                    Long totalLike, Status userStatus) {
-    return Member.builder()
-        .userName(userName)
-        .kakaoId(kakaoId)
-        .instaId(instaId)
-        .role(role)
-        .profileImageUrl(profileImageUrl)
-        .totalLike(totalLike)
-        .userStatus(userStatus)
-        .build();
+                                    String profileImageUrl, Role role, Long totalLike,
+                                    Status userStatus) {
+    return Member.builder().userName(userName).kakaoId(kakaoId).instaId(instaId).role(role)
+        .profileImageUrl(profileImageUrl).totalLike(totalLike).userStatus(userStatus).build();
   }
 
 //  public Member createMember(){
@@ -45,13 +38,8 @@ public class MemberService {
     if (member.isEmpty()) {
       throw new IllegalArgumentException("존재하지 않는 회원입니다.");
     }
-    return GetMemberInfoResponseDTO.builder()
-        .memberId(member.get().getMemberId())
-        .userName(member.get().getUserName())
-        .kakaoId(member.get().getKakaoId())
-        .totalLike(member.get().getTotalLike())
-        .profileImageUrl(member.get().getProfileImageUrl())
-        .build();
+    return new GetMemberInfoResponseDTO(member.get().getMemberId(), member.get().getUserName(),
+        member.get().getKakaoId(), member.get().getTotalLike(), member.get().getProfileImageUrl());
   }
 }
 

--- a/src/main/resources/db/prodMockSetup.sql
+++ b/src/main/resources/db/prodMockSetup.sql
@@ -22,16 +22,16 @@ VALUES (NOW(), 'insta1', 'kakao1',
 
 -- Image Table
 INSERT INTO image (created_at, image_uri)
-VALUES (NOW(), '/image/test.jpg'),
-       (NOW(), '/image/test.jpg'),
-       (NOW(), '/image/test.jpg'),
-       (NOW(), '/image/test.jpg'),
-       (NOW(), '/image/test.jpg'),
-       (NOW(), '/image/test.jpg'),
-       (NOW(), '/image/test.jpg'),
-       (NOW(), '/image/test.jpg'),
-       (NOW(), '/image/test.jpg'),
-       (NOW(), '/image/test.jpg');
+VALUES (NOW(), '/images/test.jpg'),
+       (NOW(), '/images/test.jpg'),
+       (NOW(), '/images/test.jpg'),
+       (NOW(), '/images/test.jpg'),
+       (NOW(), '/images/test.jpg'),
+       (NOW(), '/images/test.jpg'),
+       (NOW(), '/images/test.jpg'),
+       (NOW(), '/images/test.jpg'),
+       (NOW(), '/images/test.jpg'),
+       (NOW(), '/images/test.jpg');
 INSERT INTO post (created_at, nickname, popularity, published, report_count, view_count, image_id, member_id, hashtag)
 VALUES (NOW(), 'nickname1', 200, true, 1, 2000, 2, 1, '#hashtag2'),
        (NOW(), 'nickname2', 300, true, 2, 3000, 3, 2, '#hashtag3'),


### PR DESCRIPTION
## User Info User Null 이슈 해결
```java
@RequestMapping("/api")
public class MemberController {

  private final MemberService memberService;
```
## Member 정보 실제 유저 데이터로 가져오도록 수정
```java
  @ApiOperation(value = "마이페이지 계정 상세 조회")
  @GetMapping("/user/info")
  public ApiResponse<ApiResponse.CustomBody<GetMemberInfoResponseDTO>> getMyPageInfo(
      @AuthenticationPrincipal PrincipalDetails principalDetails) {
```
## Mock Up 데이터 : 이미지 경로 수정
```java
-- Image Table
INSERT INTO image (created_at, image_uri)
VALUES (NOW(), '/images/test.jpg'),
       (NOW(), '/images/test.jpg'),
       (NOW(), '/images/test.jpg'),
       (NOW(), '/images/test.jpg'),
       (NOW(), '/images/test.jpg'),
       (NOW(), '/images/test.jpg'
```