### PR TITLE
회원탈퇴 기능 수정 및 엑세스토큰 만료 상태코드 변경

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/filter/FilterResponseUtils.java
+++ b/src/main/java/com/kakaotech/team14backend/filter/FilterResponseUtils.java
@@ -3,7 +3,6 @@ package com.kakaotech.team14backend.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kakaotech.team14backend.common.ApiResponse;
 import com.kakaotech.team14backend.common.ApiResponseGenerator;
-import com.kakaotech.team14backend.exception.Exception401;
 import org.springframework.http.HttpStatus;
 
 import javax.servlet.http.HttpServletResponse;
@@ -32,7 +31,7 @@ public class FilterResponseUtils {
     }
   }
   public static void AccessTokenExpired(HttpServletResponse response) throws IOException {
-    ApiResponse<?> apiResponse = ApiResponseGenerator.fail("4111", "엑세스 토큰 만료", HttpStatus.valueOf(4111));
+    ApiResponse<?> apiResponse = ApiResponseGenerator.fail("4111", "엑세스 토큰 만료 : 재발급 요망", HttpStatus.UNAUTHORIZED);
     response.setCharacterEncoding("UTF-8");
     response.setContentType("application/json");
     response.getWriter().write(new ObjectMapper().writeValueAsString(apiResponse.getBody()));

--- a/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
@@ -101,6 +101,12 @@ public class Member {
         ", role=" + role +
         '}';
   }
+  public void makeUserInactive() {
+    this.userStatus = Status.STATUS_INACTIVE;
+  }
+  public void makeUserActive() {
+    this.userStatus = Status.STATUS_ACTIVE;
+  }
 
   public Member(String userName, String kakaoId, String instaId, Role role, Long totalLike, Status userStatus) {
     this.userName = userName;

--- a/src/main/java/com/kakaotech/team14backend/inner/member/model/Status.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/member/model/Status.java
@@ -2,7 +2,7 @@ package com.kakaotech.team14backend.inner.member.model;
 
 public enum Status {
   STATUS_ACTIVE("STATUS_ACTIVE"),
-  STATUS_DORMANT("STATUS_DORMANT");
+  STATUS_INACTIVE("STATUS_INACTIVE");
 
   String status;
   Status(String status){

--- a/src/main/java/com/kakaotech/team14backend/outer/login/service/LoginService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/login/service/LoginService.java
@@ -154,6 +154,9 @@ public class LoginService {
       memberEntity = memberService.createMember(userName, kakaoId,"none",profileImage, Role.ROLE_BEGINNER,0L, Status.STATUS_ACTIVE);
       memberRepository.save(memberEntity);
     }
+    if (memberEntity.getUserStatus().equals(Status.STATUS_INACTIVE)){
+      memberService.makeUserActive(memberEntity.getMemberId());
+    }
 
     PrincipalDetails principalDetails = new PrincipalDetails(memberEntity);
 

--- a/src/main/java/com/kakaotech/team14backend/outer/member/service/MemberService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/member/service/MemberService.java
@@ -49,7 +49,16 @@ public class MemberService {
     if (member.isEmpty()) {
       throw new IllegalArgumentException("존재하지 않는 회원입니다.");
     }
-    memberRepository.deleteByMemberId(memberId);
+    member.get().makeUserInactive();
+  }
+
+  @Transactional
+  public void makeUserActive(Long memberId){
+    Optional<Member> member = memberRepository.findById(memberId);
+    if (member.isEmpty()) {
+      throw new IllegalArgumentException("존재하지 않는 회원입니다.");
+    }
+    member.get().makeUserActive();
   }
 }
 


### PR DESCRIPTION
## 변경된 점
* 회원탈퇴 시 사용자 상태 "INACTIVE"로 변경
* 토큰 재발급이 필요한 상태 시 '4111' 코드 반환

TODO : INACTIVE 상태 한달 유지 시 데이터 삭제 로직 처리