### PR TITLE
인기 피드 조회시 DB에 저장되어 있는 게시글의 갯수가 랭킹 최하위 순위의 개수보다 적을 경우 고려

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/common/MessageCode.java
+++ b/src/main/java/com/kakaotech/team14backend/common/MessageCode.java
@@ -13,7 +13,7 @@ public enum MessageCode {
   ,
   NOT_REGISTER_MEMBER("401","회원정보가 존재하지 않습니다")
   ,
-  LEVEL_SIZE_SMALLER_THAN_20("403","각 레벨당 사이즈는 20보다 작아야합니다."),
+  LEVEL_SIZE_SMALLER_THAN_20("403","각 레벨당 사이즈는 10보다 작아야합니다."),
 
   NOT_REGISTER_POST("444","해당 게시물이 존재하지 않습니다."),
 

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/PostRandomFetcher.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/PostRandomFetcher.java
@@ -2,6 +2,7 @@ package com.kakaotech.team14backend.inner.post.model;
 
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -64,6 +65,49 @@ public class PostRandomFetcher {
         .collect(Collectors.toList());
 
     return sortedRandomIndexes;
+  }
+
+  public Map<Integer, List<Integer>> fetchRandomIndexesUnder30ForAllLevels(Map<Integer, Integer> levelCounts, int size) {
+    int totalSize = levelCounts.get(1) + levelCounts.get(2) + levelCounts.get(3);
+
+    Set<Integer> randomIndexesSet = new HashSet<>();
+
+    while (randomIndexesSet.size() < totalSize) {
+      int randomIndex = 1 + random.nextInt(size);
+      randomIndexesSet.add(randomIndex);
+    }
+
+    List<Integer> sortedRandomIndexes = randomIndexesSet.stream()
+        .sorted()
+        .collect(Collectors.toList());
+
+    Map<Integer, List<Integer>> result = new HashMap<>();
+
+    List<Integer> level3 = new ArrayList<>();
+    List<Integer> level2 = new ArrayList<>();
+    List<Integer> level1 = new ArrayList<>();
+
+    for(int i=0; i<sortedRandomIndexes.size(); i++){
+        if(sortedRandomIndexes.get(i) < PostLevel.LV3.end()){
+          level3.add(sortedRandomIndexes.get(i));
+        }else if(sortedRandomIndexes.get(i) < PostLevel.LV2.end()) {
+          level2.add(sortedRandomIndexes.get(i));
+        }else{
+          level1.add(sortedRandomIndexes.get(i));
+        }
+    }
+
+    if(!level3.isEmpty()){
+      result.put(3, level3);
+    }
+    if (!level2.isEmpty()) {
+      result.put(2, level2);
+    }
+    if (!level1.isEmpty()) {
+      result.put(1, level1);
+    }
+
+    return result;
   }
 
 }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/model/PostRandomFetcher.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/model/PostRandomFetcher.java
@@ -72,7 +72,9 @@ public class PostRandomFetcher {
 
     Set<Integer> randomIndexesSet = new HashSet<>();
 
-    while (randomIndexesSet.size() < totalSize) {
+    int bound = totalSize < size ? totalSize : size;
+
+    while (randomIndexesSet.size() < bound) {
       int randomIndex = 1 + random.nextInt(size);
       randomIndexesSet.add(randomIndex);
     }

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecase.java
@@ -2,7 +2,6 @@ package com.kakaotech.team14backend.inner.post.usecase;
 
 import com.kakaotech.team14backend.common.MessageCode;
 import com.kakaotech.team14backend.common.RedisKey;
-import com.kakaotech.team14backend.exception.Exception500;
 import com.kakaotech.team14backend.exception.MultiplePostsFoundException;
 import com.kakaotech.team14backend.exception.PostNotFoundException;
 import com.kakaotech.team14backend.inner.post.model.PostRandomFetcher;
@@ -28,25 +27,43 @@ public class FindPopularPostListUsecase {
 
   private final RedisTemplate redisTemplate;
   private final PostRandomFetcher postRandomFetcher;
-
-  public GetPopularPostListResponseDTO execute(Map<Integer, Integer> levelCounts){
-
-    Map<Integer, List<Integer>> levelIndexes = postRandomFetcher.fetchRandomIndexesForAllLevels(levelCounts);
+  private static final int MINIMUM_SIZE = 30;
+  public GetPopularPostListResponseDTO execute(Map<Integer, Integer> levelCounts, int size) {
 
     List<GetIncompletePopularPostDTO> incompletePopularPostDTOS = new ArrayList<>();
+    GetPopularPostListResponseDTO getPopularPostListResponseDTO = null;
+    Map<Integer, List<Integer>> levelIndexes = null;
 
-    for(int i = 1; i <= levelIndexes.size(); i++){
-      for(int j = 0; j < levelIndexes.get(i).size(); j++){
-        Set<LinkedHashMap<String, Object>> post = redisTemplate.opsForZSet().reverseRange(RedisKey.POPULAR_POST_KEY.getKey(), levelIndexes.get(i).get(j)-1, levelIndexes.get(i).get(j)-1);
+    levelIndexes = getLevelIndexes(levelCounts, size);
+
+    for (Map.Entry<Integer, List<Integer>> entry : levelIndexes.entrySet()) {
+      List<Integer> indexes = entry.getValue();
+      for (Integer index : indexes) {
+        Set<LinkedHashMap<String, Object>> post = redisTemplate.opsForZSet().reverseRange(RedisKey.POPULAR_POST_KEY.getKey(), index - 1, index - 1);
         // todo 해당 게시물이 Redis에 없을 때 MySQL에서 조회하는 방법 생각!
-        if(post.isEmpty()){
+        if (post.isEmpty()) {
           throw new PostNotFoundException(MessageCode.NOT_REGISTER_POST);
         }
         incompletePopularPostDTOS.add(getIncompletePopularPostDTO(post));
       }
+
     }
-    GetPopularPostListResponseDTO getPopularPostListResponseDTO = PostMapper.from(incompletePopularPostDTOS,levelIndexes);
+
+    getPopularPostListResponseDTO = PostMapper.from(incompletePopularPostDTOS, levelIndexes);
+
     return getPopularPostListResponseDTO;
+  }
+
+  private Map<Integer, List<Integer>> getLevelIndexes(Map<Integer, Integer> levelCounts, int size) {
+    Map<Integer, List<Integer>> levelIndexes;
+    if(size < MINIMUM_SIZE){
+      levelIndexes = postRandomFetcher.fetchRandomIndexesUnder30ForAllLevels(levelCounts, size);
+
+    }else{
+      levelIndexes = postRandomFetcher.fetchRandomIndexesForAllLevels(levelCounts);
+
+    }
+    return levelIndexes;
   }
 
   private GetIncompletePopularPostDTO getIncompletePopularPostDTO(Set<LinkedHashMap<String, Object>> post) {

--- a/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPostListUsecase.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/post/usecase/FindPostListUsecase.java
@@ -50,4 +50,9 @@ public class FindPostListUsecase {
         new ArrayList<>(postRepository.findAll(pageable).getContent()) :
         new ArrayList<>(postRepository.findNextPosts(lastPostId, pageable));
   }
+
+  public int findPostListSize(){
+    return postRepository.findAll().size();
+  }
+
 }

--- a/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/controller/PostController.java
@@ -98,7 +98,7 @@ public class PostController {
   public ApiResponse<ApiResponse.CustomBody<GetPopularPostListResponseDTO>> getPopularPostList(
       @RequestParam Integer level1, @RequestParam Integer level2, @RequestParam Integer level3) {
 
-    if (level1 >= 20 || level2 >= 20 || level3 >= 20) {
+    if (level1 >= 10 || level2 >= 10 || level3 >= 10) {
       throw new MaxLevelSizeException(MessageCode.LEVEL_SIZE_SMALLER_THAN_20);
     }
 

--- a/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/mapper/PostMapper.java
@@ -48,15 +48,15 @@ public class PostMapper {
       Map<Integer, List<Integer>> levelIndexes) {
     List<GetPopularPostDTO> popularPosts = new ArrayList<>();
     int h = 0;
-    for (int i = 1; i <= levelIndexes.size(); i++) {
-      for (int j = 0; j < levelIndexes.get(i).size(); j++) {
+    for (Map.Entry<Integer, List<Integer>> entry : levelIndexes.entrySet()) {
+      for(Integer index : entry.getValue()){
         GetIncompletePopularPostDTO getIncompletePopularPostDTO = getIncompletePopularPostDTOS.get(
             h++);
         GetPopularPostDTO getPopularPostDTO = new GetPopularPostDTO(
             getIncompletePopularPostDTO.getPostId(), getIncompletePopularPostDTO.getImageUri(),
             splitHashtag(getIncompletePopularPostDTO.getHashTag()),
-            getIncompletePopularPostDTO.getLikeCount(), getPostPoint(i),
-            getIncompletePopularPostDTO.getNickname(), i);
+            getIncompletePopularPostDTO.getLikeCount(), getPostPoint(entry.getKey()),
+            getIncompletePopularPostDTO.getNickname(), entry.getKey());
         popularPosts.add(getPopularPostDTO);
       }
     }
@@ -65,8 +65,7 @@ public class PostMapper {
 
 
   private static Long getPostPoint(int postLevel) {
-    Long postPoint = UsePointDecider.decidePoint(postLevel);
-    return postPoint;
+    return UsePointDecider.decidePoint(postLevel);
   }
 
   private static List<String> splitHashtag(String hashTag) {

--- a/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/post/service/PostService.java
@@ -112,8 +112,9 @@ public class PostService {
 
   public GetPopularPostListResponseDTO getPopularPostList(
       GetPopularPostListRequestDTO getPopularPostListRequestDTO) {
+    int size = findPostListUsecase.findPostListSize();
     GetPopularPostListResponseDTO getPopularPostListResponseDTO = findPopularPostListUsecase.execute(
-        getPopularPostListRequestDTO.levelSize());
+        getPopularPostListRequestDTO.levelSize(),size);
     return getPopularPostListResponseDTO;
   }
 

--- a/src/test/java/com/kakaotech/team14backend/inner/post/model/PostRandomFetcherTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/model/PostRandomFetcherTest.java
@@ -1,0 +1,99 @@
+package com.kakaotech.team14backend.inner.post.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class PostRandomFetcherTest {
+
+  private PostRandomFetcher postRandomFetcher;
+
+  @BeforeEach
+  void setUp() {
+
+    postRandomFetcher = createPostRandomFetcher();
+  }
+
+  @Test
+  void fetchRandomIndexesForAllLevels() {
+    Map<Integer, Integer> levelSize = new HashMap<>();
+    levelSize.put(1, 3);
+    levelSize.put(2, 3);
+    levelSize.put(3, 4);
+
+    Map<Integer, List<Integer>> integerListMap = postRandomFetcher.fetchRandomIndexesForAllLevels(levelSize);
+    for(Map.Entry<Integer, List<Integer>> entry : integerListMap.entrySet()){
+      System.out.println("key : " + entry.getKey() + " value : " + entry.getValue());
+    }
+
+    Assertions.assertEquals(3, integerListMap.get(1).size());
+    Assertions.assertEquals(3, integerListMap.get(2).size());
+    Assertions.assertEquals(4, integerListMap.get(3).size());
+  }
+
+  @Test
+  void fetchRandomIndexesForAllLevels_max_size() {
+    Map<Integer, Integer> levelSize = new HashMap<>();
+    levelSize.put(1, 9);
+    levelSize.put(2, 9);
+    levelSize.put(3, 9);
+
+    Map<Integer, List<Integer>> integerListMap = postRandomFetcher.fetchRandomIndexesForAllLevels(levelSize);
+    for(Map.Entry<Integer, List<Integer>> entry : integerListMap.entrySet()){
+      System.out.println("key : " + entry.getKey() + " value : " + entry.getValue());
+    }
+
+    Assertions.assertEquals(9, integerListMap.get(1).size());
+    Assertions.assertEquals(9, integerListMap.get(2).size());
+    Assertions.assertEquals(9, integerListMap.get(3).size());
+  }
+
+  @Test
+  void fetchRandomIndexesUnder30ForAllLevels_20() {
+    Map<Integer, Integer> levelSize = new HashMap<>();
+    levelSize.put(1, 3);
+    levelSize.put(2, 3);
+    levelSize.put(3, 4);
+
+
+    int totalSize = 0;
+    Map<Integer, List<Integer>> integerListMap = postRandomFetcher.fetchRandomIndexesUnder30ForAllLevels(levelSize, 20);
+    for(Map.Entry<Integer, List<Integer>> entry : integerListMap.entrySet()){
+      System.out.println("key : " + entry.getKey() + " value : " + entry.getValue());
+      totalSize += entry.getValue().size();
+    }
+
+    Assertions.assertEquals(10, totalSize);
+
+  }
+
+  @Test
+  void fetchRandomIndexesUnder30ForAllLevels_8() {
+    Map<Integer, Integer> levelSize = new HashMap<>();
+    levelSize.put(1, 3);
+    levelSize.put(2, 3);
+    levelSize.put(3, 4);
+
+
+    int totalSize = 0;
+    Map<Integer, List<Integer>> integerListMap = postRandomFetcher.fetchRandomIndexesUnder30ForAllLevels(levelSize, 8);
+    for(Map.Entry<Integer, List<Integer>> entry : integerListMap.entrySet()){
+      System.out.println("key : " + entry.getKey() + " value : " + entry.getValue());
+      totalSize += entry.getValue().size();
+    }
+
+    Assertions.assertEquals(8, totalSize);
+
+  }
+
+
+
+  private PostRandomFetcher createPostRandomFetcher() {
+    return new PostRandomFetcher();
+  }
+
+}

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUnder30Test.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUnder30Test.java
@@ -1,0 +1,66 @@
+package com.kakaotech.team14backend.inner.post.usecase;
+
+import com.kakaotech.team14backend.common.RedisKey;
+import com.kakaotech.team14backend.inner.post.model.Post;
+import com.kakaotech.team14backend.inner.post.model.PostRandomFetcher;
+import com.kakaotech.team14backend.inner.post.repository.PostRepository;
+import com.kakaotech.team14backend.outer.post.dto.GetIncompletePopularPostDTO;
+import com.kakaotech.team14backend.outer.post.dto.GetPopularPostListResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@SpringBootTest
+
+@EnabledIf(value = "#{environment.getActiveProfiles()[0] == 'local'}", loadContext = true)
+
+@Sql("classpath:db/testSetup.sql")
+public class FindPopularPostListUnder30Test {
+
+  @Autowired
+  private FindPopularPostListUsecase findPopularPostListUsecase;
+
+  @Autowired
+  private PostRandomFetcher postRandomFetcher;
+
+  @Autowired
+  private RedisTemplate redisTemplate;
+
+  @Autowired
+  private PostRepository postRepository;
+
+  @BeforeEach
+  void setUp() {
+    redisTemplate.delete(RedisKey.POPULAR_POST_KEY.getKey());
+    List<Post> posts = postRepository.findAll().subList(0,29);
+    posts.forEach(post -> {
+      redisTemplate.opsForZSet().add(RedisKey.POPULAR_POST_KEY.getKey(),new GetIncompletePopularPostDTO(post.getPostId(),post.getImage().getImageUri(),post.getHashtag(),post.getPostLikeCount().getLikeCount(),post.getPopularity(),post.getNickname()),post.getPopularity());
+    });
+  }
+
+  @Test
+  void execute() {
+
+    Map<Integer, Integer> levelCounts = new HashMap<>();
+
+    levelCounts.put(3, 4);
+    levelCounts.put(2, 3);
+    levelCounts.put(1, 3);
+
+    GetPopularPostListResponseDTO getPopularPostListResponseDTO = findPopularPostListUsecase.execute(
+        levelCounts, 20);
+
+    System.out.println(getPopularPostListResponseDTO);
+
+  }
+
+
+}

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecaseOver30Test.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/FindPopularPostListUsecaseOver30Test.java
@@ -22,7 +22,7 @@ import org.springframework.test.context.junit.jupiter.EnabledIf;
 @EnabledIf(value = "#{environment.getActiveProfiles()[0] == 'local'}", loadContext = true)
 
 @Sql("classpath:db/testSetup.sql")
-class FindPopularPostListUsecaseTest {
+class FindPopularPostListUsecaseOver30Test {
 
   @Autowired
   private FindPopularPostListUsecase findPopularPostListUsecase;
@@ -58,7 +58,7 @@ class FindPopularPostListUsecaseTest {
     levelCounts.put(1, 3);
 
     GetPopularPostListResponseDTO getPopularPostListResponseDTO = findPopularPostListUsecase.execute(
-        levelCounts);
+        levelCounts,300);
     int size = getPopularPostListResponseDTO.popularPosts().size();
 
     org.assertj.core.api.Assertions.assertThat(size).isEqualTo(10);

--- a/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
+++ b/src/test/java/com/kakaotech/team14backend/outer/controller/PostControllerTest.java
@@ -192,7 +192,7 @@ public class PostControllerTest {
 
     ResultActions resultActions = mockMvc.perform(
         get("/api/popular-post")
-            .param("level3", "20")
+            .param("level3", "10")
             .param("level2", "3")
             .param("level1", "3")
             .contentType(MediaType.APPLICATION_JSON));


### PR DESCRIPTION
주요 변경 사항
---

1. DB에 저장되어있는 게시글의 개수가 인기 피드 전체 조회 시 요구하는 게시글 size의 총합보다 작을 경우를 고려
2. DB에 저장되어있는 게시글의 갯수가 랭킹 최하위 순위보다 적을 경우를 고려
3. 조회시 모든 게시글의 레벨이 없을 경우 고려

위 3가지를 고려하여 인기 피드 리팩토링 및 테스트 수행


관련 이슈 : https://github.com/Step3-kakao-tech-campus/Team14_BE/issues/159