### PR TITLE
fix : member 엔티티 pk 수정

### DIFF
--- a/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
+++ b/src/main/java/com/kakaotech/team14backend/inner/member/model/Member.java
@@ -28,9 +28,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @NoArgsConstructor(access=PROTECTED)
 @Getter
 public class Member {
-
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long memberId;
 
   @OneToMany(mappedBy = "member")
@@ -109,6 +107,7 @@ public class Member {
   }
 
   public Member(String userName, String kakaoId, String instaId, Role role, Long totalLike, Status userStatus) {
+    this.memberId = Long.valueOf(kakaoId);
     this.userName = userName;
     this.kakaoId = kakaoId;
     this.instaId = instaId;

--- a/src/main/java/com/kakaotech/team14backend/outer/member/service/MemberService.java
+++ b/src/main/java/com/kakaotech/team14backend/outer/member/service/MemberService.java
@@ -23,7 +23,7 @@ public class MemberService {
   public static Member createMember(String userName, String kakaoId, String instaId,
                                     String profileImageUrl, Role role, Long totalLike,
                                     Status userStatus) {
-    return Member.builder().userName(userName).kakaoId(kakaoId).instaId(instaId).role(role)
+    return Member.builder().memberId(Long.valueOf(kakaoId)).userName(userName).kakaoId(kakaoId).instaId(instaId).role(role)
         .profileImageUrl(profileImageUrl).totalLike(totalLike).userStatus(userStatus).build();
   }
 

--- a/src/main/resources/db/prodMockSetup.sql
+++ b/src/main/resources/db/prodMockSetup.sql
@@ -8,16 +8,16 @@ TRUNCATE TABLE point;
 
 
 -- Member Table
-INSERT INTO member (created_at, insta_id, kakao_id, profile_image_url, total_like, updated_at,
+INSERT INTO member (member_id,created_at, insta_id, kakao_id, profile_image_url, total_like, updated_at,
                     user_name, user_status,
                     role)
-VALUES (NOW(), 'insta1', 'kakao1',
+VALUES (1L,NOW(), 'insta1', 'kakao1',
         'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg', 10,
         NOW(), 'user1', 'STATUS_ACTIVE', 'ROLE_BEGINNER'),
-       (NOW(), 'insta2', 'kakao2',
+       (2L,NOW(), 'insta2', 'kakao2',
         'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg', 20,
         NOW(), 'user2', 'STATUS_ACTIVE', 'ROLE_BEGINNER'),
-       (NOW(), 'insta3', 'kakao3',
+       (3L,NOW(), 'insta3', 'kakao3',
         'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg', 30,
         NOW(), 'user3', 'STATUS_DORMANT', 'ROLE_BEGINNER');
 

--- a/src/main/resources/db/testSetup.sql
+++ b/src/main/resources/db/testSetup.sql
@@ -6,16 +6,16 @@ TRUNCATE TABLE post_like_count;
 TRUNCATE TABLE point;
 SET REFERENTIAL_INTEGRITY True;
 -- Member Table
-INSERT INTO member (created_at, insta_id, kakao_id, profile_image_url, total_like, updated_at,
+INSERT INTO member (member_id,created_at, insta_id, kakao_id, profile_image_url, total_like, updated_at,
                     user_name, user_status,
                     role)
-VALUES (NOW(), 'insta1', 'kakao1',
+VALUES (1L,NOW(), 'insta1', 'kakao1',
         'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg', 10,
         NOW(), 'user1', 'STATUS_ACTIVE', 'ROLE_BEGINNER'),
-       (NOW(), 'insta2', 'kakao2',
+       (2L,NOW(), 'insta2', 'kakao2',
         'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg', 20,
         NOW(), 'user2', 'STATUS_ACTIVE', 'ROLE_BEGINNER'),
-       (NOW(), 'insta3', 'kakao3',
+       (3L,NOW(), 'insta3', 'kakao3',
         'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg', 30,
         NOW(), 'user3', 'STATUS_DORMANT', 'ROLE_BEGINNER');
 

--- a/src/test/java/com/kakaotech/team14backend/inner/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/member/repository/MemberRepositoryTest.java
@@ -38,7 +38,7 @@ public class MemberRepositoryTest {
     // Given
     Member mockMember = new Member(
         "TestUser",
-        "testKakaoId",
+        "1111",
         "testInstaId",
         Role.ROLE_USER,
         0L,
@@ -65,7 +65,7 @@ public class MemberRepositoryTest {
     Long testId = 1L;
     Member mockMember = new Member(
         "TestUser",
-        "testKakaoId",
+        "1111",
         "testInstaId",
         Role.ROLE_USER,
         0L,
@@ -86,7 +86,7 @@ public class MemberRepositoryTest {
     // Given
     Member mockMember1 = new Member(
         "TestUser1",
-        "testKakaoId1",
+        "1111",
         "testInstaId1",
         Role.ROLE_USER,
         0L,
@@ -94,7 +94,7 @@ public class MemberRepositoryTest {
     );
     Member mockMember2 = new Member(
         "TestUser2",
-        "testKakaoId2",
+        "2222",
         "testInstaId2",
         Role.ROLE_USER,
         0L,
@@ -118,7 +118,7 @@ public class MemberRepositoryTest {
     Long testId = 1L;
     Member mockMember = new Member(
         "TestUser",
-        "testKakaoId",
+        "1111",
         "testInstaId",
         Role.ROLE_USER,
         0L,

--- a/src/test/java/com/kakaotech/team14backend/inner/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/member/repository/MemberRepositoryTest.java
@@ -51,7 +51,7 @@ public class MemberRepositoryTest {
     // Then
     Member foundMember = memberRepository.findByKakaoId("testKakaoId");
     assertEquals("TestUser", foundMember.getUserName());
-    assertEquals("testKakaoId", foundMember.getKakaoId());
+    assertEquals("1111", foundMember.getKakaoId());
     assertEquals("testInstaId", foundMember.getInstaId());
     assertEquals(Role.ROLE_USER, foundMember.getRole());
     assertEquals(0L, foundMember.getTotalLike());

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SetPostLikeUsecaseTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/SetPostLikeUsecaseTest.java
@@ -59,7 +59,7 @@ public class SetPostLikeUsecaseTest {
     SetPostLikeDTO setPostLikeDTO = new SetPostLikeDTO(postId, memberId);
 
 
-    Member member = new Member(memberId,"sonny", "sonny1234", "asdf324","none", Role.ROLE_BEGINNER, 0L,Status.STATUS_ACTIVE);
+    Member member = new Member(memberId,"sonny", "1234", "asdf324","none", Role.ROLE_BEGINNER, 0L,Status.STATUS_ACTIVE);
 
     Image image = new Image("/image/firstPhoto");
     PostLikeCount postLikeCount = PostLikeCount.createPostLikeCount();
@@ -85,7 +85,7 @@ public class SetPostLikeUsecaseTest {
     Long memberId = 1L;
     SetPostLikeDTO setPostLikeDTO = new SetPostLikeDTO(postId, memberId);
 
-    Member member = new Member("sonny", "sonny1234", "asdf324", Role.ROLE_BEGINNER, 0L,
+    Member member = new Member("sonny", "1234", "asdf324", Role.ROLE_BEGINNER, 0L,
         Status.STATUS_ACTIVE);
     Image image = new Image("/image/firstPhoto");
     PostLikeCount postLikeCount = PostLikeCount.createPostLikeCount();
@@ -114,7 +114,7 @@ public class SetPostLikeUsecaseTest {
     Long memberId = 1L;
     SetPostLikeDTO setPostLikeDTO = new SetPostLikeDTO(postId, memberId);
 
-    Member member = new Member("sonny", "sonny1234", "asdf324", Role.ROLE_BEGINNER, 0L,
+    Member member = new Member("sonny", "1234", "asdf324", Role.ROLE_BEGINNER, 0L,
         Status.STATUS_ACTIVE);
     Image image = new Image("/image/firstPhoto");
     PostLikeCount postLikeCount = PostLikeCount.createPostLikeCount();
@@ -178,7 +178,7 @@ public class SetPostLikeUsecaseTest {
     Long memberId = 1L;
     SetPostLikeDTO setPostLikeDTO = new SetPostLikeDTO(postId, memberId);
 
-    Member member = new Member("sonny", "sonny1234", "asdf324", Role.ROLE_BEGINNER, 0L,
+    Member member = new Member("sonny", "1234", "asdf324", Role.ROLE_BEGINNER, 0L,
         Status.STATUS_ACTIVE);
     when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
     when(postRepository.findById(postId)).thenReturn(

--- a/src/test/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostViewCountTest.java
+++ b/src/test/java/com/kakaotech/team14backend/inner/post/usecase/UpdatePostViewCountTest.java
@@ -57,7 +57,7 @@ class UpdatePostViewCountTest {
       redisTemplate.delete(key);
     }
 
-    Member member = new Member("sonny", "sonny1234", "asdf324", Role.ROLE_BEGINNER, 0L,
+    Member member = new Member("sonny", "1234", "asdf324", Role.ROLE_BEGINNER, 0L,
         Status.STATUS_ACTIVE);
     memberRepository.save(member);
 


### PR DESCRIPTION
### 변경된 점
기존 auto_increment로 생성되는 memberId PK를 카카오에서 제공해주는 UUID인 kakaoId와 동일하 값으로 설정